### PR TITLE
Migrate original `auto-changelog.js` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/auto-changelog/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,6 @@
 module.exports = {
   collectCoverage: true,
   coverageReporters: ['text', 'html'],
-  coverageThreshold: {
-    global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
-    },
-  },
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   testEnvironment: 'node',
   testRegex: ['\\.test\\.js$'],

--- a/package.json
+++ b/package.json
@@ -7,12 +7,17 @@
     "access": "public"
   },
   "main": "src/index.js",
+  "bin": "src/cli.js",
   "engines": {
     "node": ">=12.0.0"
   },
   "files": [
     "src/"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/auto-changelog"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
@@ -20,7 +25,12 @@
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:json": "prettier '**/*.json' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:json --check",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:json --write"
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:json --write",
+    "update-changelog": "node ./src/cli.js"
+  },
+  "dependencies": {
+    "cross-spawn": "^7.0.3",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^6.0.0",

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -1,0 +1,305 @@
+const semver = require('semver');
+
+const { orderedChangeCategories, unreleased } = require('./constants');
+
+const changelogTitle = '# Changelog';
+const changelogDescription = `All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).`;
+
+// Stringification helpers
+
+function stringifyCategory(category, changes) {
+  const categoryHeader = `### ${category}`;
+  if (changes.length === 0) {
+    return categoryHeader;
+  }
+  const changeDescriptions = changes
+    .map((description) => `- ${description}`)
+    .join('\n');
+  return `${categoryHeader}\n${changeDescriptions}`;
+}
+
+function stringifyRelease(version, categories, { date, status } = {}) {
+  const releaseHeader = `## [${version}]${date ? ` - ${date}` : ''}${
+    status ? ` [${status}]` : ''
+  }`;
+  const categorizedChanges = orderedChangeCategories
+    .filter((category) => categories[category])
+    .map((category) => {
+      const changes = categories[category];
+      return stringifyCategory(category, changes);
+    })
+    .join('\n\n');
+  if (categorizedChanges === '') {
+    return releaseHeader;
+  }
+  return `${releaseHeader}\n${categorizedChanges}`;
+}
+
+function stringifyReleases(releases, changes) {
+  const stringifiedUnreleased = stringifyRelease(
+    unreleased,
+    changes[unreleased],
+  );
+  const stringifiedReleases = releases.map(({ version, date, status }) => {
+    const categories = changes[version];
+    return stringifyRelease(version, categories, { date, status });
+  });
+
+  return [stringifiedUnreleased, ...stringifiedReleases].join('\n\n');
+}
+
+function withTrailingSlash(url) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+function getCompareUrl(repoUrl, firstRef, secondRef) {
+  return `${withTrailingSlash(repoUrl)}compare/${firstRef}...${secondRef}`;
+}
+
+function getTagUrl(repoUrl, tag) {
+  return `${withTrailingSlash(repoUrl)}releases/tag/${tag}`;
+}
+
+function stringifyLinkReferenceDefinitions(repoUrl, releases) {
+  const orderedReleases = releases
+    .map(({ version }) => version)
+    .sort((a, b) => semver.gt(a, b));
+
+  // The "Unreleased" section represents all changes made since the *highest*
+  // release, not the most recent release. This is to accomodate patch releases
+  // of older versions that don't represent the latest set of changes.
+  //
+  // For example, if a library has a v2.0.0 but the v1.0.0 release needed a
+  // security update, the v1.0.1 release would then be the most recent, but the
+  // range of unreleased changes would remain `v2.0.0...HEAD`.
+  const unreleasedLinkReferenceDefinition = `[${unreleased}]: ${getCompareUrl(
+    repoUrl,
+    `v${orderedReleases[0]}`,
+    'HEAD',
+  )}`;
+
+  // The "previous" release that should be used for comparison is not always
+  // the most recent release chronologically. The _highest_ version that is
+  // lower than the current release is used as the previous release, so that
+  // patch releases on older releases can be accomodated.
+  const releaseLinkReferenceDefinitions = releases
+    .map(({ version }) => {
+      if (version === orderedReleases[orderedReleases.length - 1]) {
+        return `[${version}]: ${getTagUrl(repoUrl, `v${version}`)}`;
+      }
+      const versionIndex = orderedReleases.indexOf(version);
+      const previousVersion = orderedReleases
+        .slice(versionIndex)
+        .find((releaseVersion) => {
+          return semver.gt(version, releaseVersion);
+        });
+      return `[${version}]: ${getCompareUrl(
+        repoUrl,
+        `v${previousVersion}`,
+        `v${version}`,
+      )}`;
+    })
+    .join('\n');
+  return `${unreleasedLinkReferenceDefinition}\n${releaseLinkReferenceDefinitions}${
+    releases.length > 0 ? '\n' : ''
+  }`;
+}
+
+/**
+ * @typedef {import('./constants.js').Unreleased} Unreleased
+ * @typedef {import('./constants.js').ChangeCategories ChangeCategories}
+ */
+/**
+ * @typedef {import('./constants.js').Version} Version
+ */
+/**
+ * Release metadata.
+ * @typedef {Object} ReleaseMetadata
+ * @property {string} date - An ISO-8601 formatted date, representing the
+ *   release date.
+ * @property {string} status -The status of the release (e.g. 'WITHDRAWN', 'DEPRECATED')
+ * @property {Version} version - The version of the current release.
+ */
+
+/**
+ * Category changes. A list of changes in a single category.
+ * @typedef {Array<string>} CategoryChanges
+ */
+
+/**
+ * Release changes, organized by category
+ * @typedef {Record<keyof ChangeCategories, CategoryChanges>} ReleaseChanges
+ */
+
+/**
+ * Changelog changes, organized by release and by category.
+ * @typedef {Record<Version|Unreleased, ReleaseChanges>} ChangelogChanges
+ */
+
+/**
+ * A changelog that complies with the ["keep a changelog" v1.1.0 guidelines]{@link https://keepachangelog.com/en/1.0.0/}.
+ *
+ * This changelog starts out completely empty, and allows new releases and
+ * changes to be added such that the changelog remains compliant at all times.
+ * This can be used to help validate the contents of a changelog, normalize
+ * formatting, update a changelog, or build one from scratch.
+ */
+class Changelog {
+  /**
+   * Construct an empty changelog
+   *
+   * @param {Object} options
+   * @param {string} options.repoUrl - The GitHub repository URL for the current project
+   */
+  constructor({ repoUrl }) {
+    this._releases = [];
+    this._changes = { [unreleased]: {} };
+    this._repoUrl = repoUrl;
+  }
+
+  /**
+   * Add a release to the changelog
+   *
+   * @param {Object} options
+   * @param {boolean} [options.addToStart] - Determines whether the release is
+   *   added to the top or bottom of the changelog. This defaults to 'true'
+   *   because new releases should be added to the top of the changelog. This
+   *   should be set to 'false' when parsing a changelog top-to-bottom.
+   * @param {string} [options.date] - An ISO-8601 formatted date, representing the
+   *   release date.
+   * @param {string} [options.status] - The status of the release (e.g.
+   *   'WITHDRAWN', 'DEPRECATED')
+   * @param {Version} options.version - The version of the current release,
+   *   which should be a [semver]{@link https://semver.org/spec/v2.0.0.html}-
+   *   compatible version.
+   */
+  addRelease({ addToStart = true, date, status, version }) {
+    if (!version) {
+      throw new Error('Version required');
+    } else if (semver.valid(version) === null) {
+      throw new Error(`Not a valid semver version: '${version}'`);
+    } else if (this._changes[version]) {
+      throw new Error(`Release already exists: '${version}'`);
+    }
+
+    this._changes[version] = {};
+    const newRelease = { version, date, status };
+    if (addToStart) {
+      this._releases.unshift(newRelease);
+    } else {
+      this._releases.push(newRelease);
+    }
+  }
+
+  /**
+   * Add a change to the changelog
+   *
+   * @param {Object} options
+   * @param {boolean} [options.addToStart] - Determines whether the change is
+   *   added to the top or bottom of the list of changes in this category. This
+   *   defaults to 'true' because changes should be in reverse-chronological
+   *   order. This should be set to 'false' when parsing a changelog top-to-
+   *   bottom.
+   * @param {string} options.category - The category of the change.
+   * @param {string} options.description - The description of the change.
+   * @param {Version} [options.version] - The version this change was released
+   *  in. If this is not given, the change is assumed to be unreleased.
+   */
+  addChange({ addToStart = true, category, description, version }) {
+    if (!category) {
+      throw new Error('Category required');
+    } else if (!orderedChangeCategories.includes(category)) {
+      throw new Error(`Unrecognized category: '${category}'`);
+    } else if (!description) {
+      throw new Error('Description required');
+    } else if (version !== undefined && !this._changes[version]) {
+      throw new Error(`Specified release version does not exist: '${version}'`);
+    }
+
+    const release = version
+      ? this._changes[version]
+      : this._changes[unreleased];
+
+    if (!release[category]) {
+      release[category] = [];
+    }
+    if (addToStart) {
+      release[category].unshift(description);
+    } else {
+      release[category].push(description);
+    }
+  }
+
+  /**
+   * Migrate all unreleased changes to a release section.
+   *
+   * Changes are migrated in their existing categories, and placed above any
+   * pre-existing changes in that category.
+   *
+   * @param {Version} version - The release version to migrate unreleased
+   *   changes to.
+   */
+  migrateUnreleasedChangesToRelease(version) {
+    const releaseChanges = this._changes[version];
+    if (!releaseChanges) {
+      throw new Error(`Specified release version does not exist: '${version}'`);
+    }
+
+    const unreleasedChanges = this._changes[unreleased];
+
+    for (const category of Object.keys(unreleasedChanges)) {
+      if (releaseChanges[category]) {
+        releaseChanges[category] = [
+          ...unreleasedChanges[category],
+          ...releaseChanges[category],
+        ];
+      } else {
+        releaseChanges[category] = unreleasedChanges[category];
+      }
+    }
+    this._changes[unreleased] = {};
+  }
+
+  /**
+   * Gets the metadata for all releases.
+   * @returns {Array<ReleaseMetadata>} The metadata for each release.
+   */
+  getReleases() {
+    return this._releases;
+  }
+
+  /**
+   * Gets the changes in the given release, organized by category.
+   * @param {Version} version - The version of the release being retrieved.
+   * @returns {ReleaseChanges} The changes included in the given released.
+   */
+  getReleaseChanges(version) {
+    return this._changes[version];
+  }
+
+  /**
+   * Gets all changes that have not yet been released
+   * @returns {ReleaseChanges} The changes that have not yet been released.
+   */
+  getUnreleasedChanges() {
+    return this._changes[unreleased];
+  }
+
+  /**
+   * The stringified changelog, formatted according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+   * @returns {string} The stringified changelog.
+   */
+  toString() {
+    return `${changelogTitle}
+${changelogDescription}
+
+${stringifyReleases(this._releases, this._changes)}
+
+${stringifyLinkReferenceDefinitions(this._repoUrl, this._releases)}`;
+  }
+}
+
+module.exports = Changelog;

--- a/src/changelog.test.js
+++ b/src/changelog.test.js
@@ -1,0 +1,19 @@
+const Changelog = require('./changelog');
+
+const emptyChangelog = `# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: fake://metamask.io/compare/vundefined...HEAD
+`;
+
+describe('Changelog', () => {
+  it('should allow creating an empty changelog', () => {
+    const changelog = new Changelog({ repoUrl: 'fake://metamask.io' });
+    expect(changelog.toString()).toStrictEqual(emptyChangelog);
+  });
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/* eslint-disable node/no-process-exit */
+
+const fs = require('fs').promises;
+
+const { updateChangelog } = require('./updateChangelog');
+const { unreleased } = require('./constants');
+
+const command = 'yarn update-changelog';
+
+const helpText = `Usage: ${command} [--rc] [-h|--help]
+Update CHANGELOG.md with any changes made since the most recent release.
+
+Options:
+      --rc    Add new changes to the current release header, rather than to the
+                '${unreleased}' section.
+  -h, --help  Display this help and exit.
+
+New commits will be added to the "${unreleased}" section (or to the section for the
+current release if the '--rc' flag is used) in reverse chronological order. Any
+commits for PRs that are represented already in the changelog will be ignored.
+
+If the '--rc' flag is used and the section for the current release does not yet
+exist, it will be created.
+`;
+
+// eslint-disable-next-line node/no-process-env
+const npmPackageVersion = process.env.npm_package_version;
+// eslint-disable-next-line node/no-process-env
+const npmPackageRepositoryUrl = process.env.npm_package_repository_url;
+
+async function main() {
+  if (!npmPackageVersion) {
+    console.error(
+      `npm package version not found. Please run this as an npm script from a project with the 'version' field set.`,
+    );
+  } else if (!npmPackageRepositoryUrl) {
+    console.error(
+      `npm package repository URL not found. Please run this as an npm script from a project with the 'repository' field set.`,
+    );
+  }
+
+  const args = process.argv.slice(2);
+  let isReleaseCandidate = false;
+
+  for (const arg of args) {
+    if (arg === '--rc') {
+      isReleaseCandidate = true;
+    } else if (['--help', '-h'].includes(arg)) {
+      console.log(helpText);
+      process.exit(0);
+    } else {
+      console.error(
+        `Unrecognized argument: ${arg}\nTry '${command} --help' for more information.\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const changelogFilename = 'CHANGELOG.md';
+  const changelogContent = await fs.readFile(changelogFilename, {
+    encoding: 'utf8',
+  });
+
+  const newChangelogContent = await updateChangelog({
+    changelogContent,
+    currentVersion: npmPackageVersion,
+    repoUrl: npmPackageRepositoryUrl,
+    isReleaseCandidate,
+  });
+
+  await fs.writeFile(changelogFilename, newChangelogContent);
+
+  console.log('CHANGELOG updated');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,68 @@
+/**
+ * Version string
+ * @typedef {string} Version - A [SemVer]{@link https://semver.org/spec/v2.0.0.html}-
+ *   compatible version string.
+ */
+
+/**
+ * Change categories.
+ *
+ * Most of these categories are from [Keep a Changelog]{@link https://keepachangelog.com/en/1.0.0/}.
+ * The "Uncategorized" category was added because we have many changes from
+ * older releases that would be difficult to categorize.
+ *
+ * @typedef {Record<string, string>} ChangeCategories
+ * @property {'Added'} Added - for new features.
+ * @property {'Changed'} Changed - for changes in existing functionality.
+ * @property {'Deprecated'} Deprecated - for soon-to-be removed features.
+ * @property {'Fixed'} Fixed - for any bug fixes.
+ * @property {'Removed'} Removed - for now removed features.
+ * @property {'Security'} Security - in case of vulnerabilities.
+ * @property {'Uncategorized'} Uncategorized - for any changes that have not
+ *   yet been categorized.
+ */
+
+/**
+ * @type {ChangeCategories}
+ */
+const changeCategories = {
+  Added: 'Added',
+  Changed: 'Changed',
+  Deprecated: 'Deprecated',
+  Fixed: 'Fixed',
+  Removed: 'Removed',
+  Security: 'Security',
+  Uncategorized: 'Uncategorized',
+};
+
+/**
+ * Change categories in the order in which they should be listed in the
+ * changelog.
+ *
+ * @type {Array<keyof ChangeCategories>}
+ */
+const orderedChangeCategories = [
+  'Uncategorized',
+  'Added',
+  'Changed',
+  'Deprecated',
+  'Removed',
+  'Fixed',
+  'Security',
+];
+
+/**
+ * The header for the section of the changelog listing unreleased changes.
+ * @typedef {'Unreleased'} Unreleased
+ */
+
+/**
+ * @type {Unreleased}
+ */
+const unreleased = 'Unreleased';
+
+module.exports = {
+  changeCategories,
+  orderedChangeCategories,
+  unreleased,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
-module.exports = function greeter(name) {
-  return `Hello, ${name}!`;
+const { updateChangelog } = require('./updateChangelog');
+
+module.exports = {
+  updateChangelog,
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,9 +1,0 @@
-const greeter = require('.');
-
-describe('Test', () => {
-  it('greets', () => {
-    const name = 'Huey';
-    const result = greeter(name);
-    expect(result).toStrictEqual('Hello, Huey!');
-  });
-});

--- a/src/parseChangelog.js
+++ b/src/parseChangelog.js
@@ -1,0 +1,84 @@
+const Changelog = require('./changelog');
+const { unreleased } = require('./constants');
+
+function truncated(line) {
+  return line.length > 80 ? `${line.slice(0, 80)}...` : line;
+}
+
+/**
+ * Constructs a Changelog instance that represents the given changelog, which
+ * is parsed for release and change informatino.
+ * @param {Object} options
+ * @param {string} options.changelogContent - The changelog to parse
+ * @param {string} options.repoUrl - The GitHub repository URL for the current
+ *   project.
+ * @returns {Changelog} A changelog instance that reflects the changelog text
+ *   provided.
+ */
+function parseChangelog({ changelogContent, repoUrl }) {
+  const changelogLines = changelogContent.split('\n');
+  const changelog = new Changelog({ repoUrl });
+
+  const unreleasedHeaderIndex = changelogLines.indexOf(`## [${unreleased}]`);
+  if (unreleasedHeaderIndex === -1) {
+    throw new Error(`Failed to find ${unreleased} header`);
+  }
+  const unreleasedLinkReferenceDefinition = changelogLines.findIndex((line) => {
+    return line.startsWith(`[${unreleased}]: `);
+  });
+  if (unreleasedLinkReferenceDefinition === -1) {
+    throw new Error(`Failed to find ${unreleased} link reference definition`);
+  }
+
+  const contentfulChangelogLines = changelogLines
+    .slice(unreleasedHeaderIndex + 1, unreleasedLinkReferenceDefinition)
+    .filter((line) => line !== '');
+
+  let mostRecentRelease;
+  let mostRecentCategory;
+  for (const line of contentfulChangelogLines) {
+    if (line.startsWith('## [')) {
+      const results = line.match(
+        /^## \[(\d+\.\d+\.\d+)\](?: - (\d\d\d\d-\d\d-\d\d))?(?: \[(\w+)\])?/u,
+      );
+      if (results === null) {
+        throw new Error(`Malformed release header: '${truncated(line)}'`);
+      }
+      mostRecentRelease = results[1];
+      mostRecentCategory = undefined;
+      const date = results[2];
+      const status = results[3];
+      changelog.addRelease({
+        addToStart: false,
+        date,
+        status,
+        version: mostRecentRelease,
+      });
+    } else if (line.startsWith('### ')) {
+      const results = line.match(/^### (\w+)$\b/u);
+      if (results === null) {
+        throw new Error(`Malformed category header: '${truncated(line)}'`);
+      }
+      mostRecentCategory = results[1];
+    } else if (line.startsWith('- ')) {
+      if (mostRecentCategory === undefined) {
+        throw new Error(`Category missing for change: '${truncated(line)}'`);
+      }
+      const description = line.slice(2);
+      changelog.addChange({
+        addToStart: false,
+        category: mostRecentCategory,
+        description,
+        version: mostRecentRelease,
+      });
+    } else if (mostRecentRelease === null) {
+      continue;
+    } else {
+      throw new Error(`Unrecognized line: '${truncated(line)}'`);
+    }
+  }
+
+  return changelog;
+}
+
+module.exports = { parseChangelog };

--- a/src/runCommand.js
+++ b/src/runCommand.js
@@ -1,0 +1,79 @@
+const spawn = require('cross-spawn');
+
+/**
+ * Run a command to completion using the system shell.
+ *
+ * This will run a command with the specified arguments, and resolve when the
+ * process has exited. The STDOUT stream is monitored for output, which is
+ * returned after being split into lines. All output is expected to be UTF-8
+ * encoded, and empty lines are removed from the output.
+ *
+ * Anything received on STDERR is assumed to indicate a problem, and is tracked
+ * as an error.
+ *
+ * @param {string} command - The command to run
+ * @param {Array<string>} [args] - The arguments to pass to the command
+ * @returns {Array<string>} Lines of output received via STDOUT
+ */
+async function runCommand(command, args) {
+  const output = [];
+  let mostRecentError;
+  let errorSignal;
+  let errorCode;
+  const internalError = new Error('Internal');
+  try {
+    await new Promise((resolve, reject) => {
+      const childProcess = spawn(command, args, { encoding: 'utf8' });
+      childProcess.stdout.setEncoding('utf8');
+      childProcess.stderr.setEncoding('utf8');
+
+      childProcess.on('error', (error) => {
+        mostRecentError = error;
+      });
+
+      childProcess.stdout.on('data', (message) => {
+        const nonEmptyLines = message.split('\n').filter((line) => line !== '');
+        output.push(...nonEmptyLines);
+      });
+
+      childProcess.stderr.on('data', (message) => {
+        mostRecentError = new Error(message.trim());
+      });
+
+      childProcess.once('exit', (code, signal) => {
+        if (code === 0) {
+          return resolve();
+        }
+        errorCode = code;
+        errorSignal = signal;
+        return reject(internalError);
+      });
+    });
+  } catch (error) {
+    /**
+     * The error is re-thrown here in an `async` context to preserve the stack trace. If this was
+     * was thrown inside the Promise constructor, the stack trace would show a few frames of
+     * Node.js internals then end, without indicating where `runCommand` was called.
+     */
+    if (error === internalError) {
+      let errorMessage;
+      if (errorCode !== null && errorSignal !== null) {
+        errorMessage = `Terminated by signal '${errorSignal}'; exited with code '${errorCode}'`;
+      } else if (errorSignal !== null) {
+        errorMessage = `Terminaled by signal '${errorSignal}'`;
+      } else if (errorCode === null) {
+        errorMessage = 'Exited with no code or signal';
+      } else {
+        errorMessage = `Exited with code '${errorCode}'`;
+      }
+      const improvedError = new Error(errorMessage);
+      if (mostRecentError) {
+        improvedError.cause = mostRecentError;
+      }
+      throw improvedError;
+    }
+  }
+  return output;
+}
+
+module.exports = runCommand;

--- a/src/updateChangelog.js
+++ b/src/updateChangelog.js
@@ -1,0 +1,171 @@
+const assert = require('assert').strict;
+const runCommand = require('./runCommand');
+const { parseChangelog } = require('./parseChangelog');
+const { changeCategories } = require('./constants');
+
+async function getMostRecentTag() {
+  const [mostRecentTagCommitHash] = await runCommand('git', [
+    'rev-list',
+    '--tags',
+    '--max-count=1',
+  ]);
+  const [mostRecentTag] = await runCommand('git', [
+    'describe',
+    '--tags',
+    mostRecentTagCommitHash,
+  ]);
+  assert.equal(mostRecentTag[0], 'v', 'Most recent tag should start with v');
+  return mostRecentTag;
+}
+
+async function getCommits(commitHashes) {
+  const commits = [];
+  for (const commitHash of commitHashes) {
+    const [subject] = await runCommand('git', [
+      'show',
+      '-s',
+      '--format=%s',
+      commitHash,
+    ]);
+
+    let prNumber;
+    let description = subject;
+
+    // Squash & Merge: the commit subject is parsed as `<description> (#<PR ID>)`
+    if (subject.match(/\(#\d+\)/u)) {
+      const matchResults = subject.match(/\(#(\d+)\)/u);
+      prNumber = matchResults[1];
+      description = subject.match(/^(.+)\s\(#\d+\)/u)[1];
+      // Merge: the PR ID is parsed from the git subject (which is of the form `Merge pull request
+      // #<PR ID> from <branch>`, and the description is assumed to be the first line of the body.
+      // If no body is found, the description is set to the commit subject
+    } else if (subject.match(/#\d+\sfrom/u)) {
+      const matchResults = subject.match(/#(\d+)\sfrom/u);
+      prNumber = matchResults[1];
+      const [firstLineOfBody] = await runCommand('git', [
+        'show',
+        '-s',
+        '--format=%b',
+        commitHash,
+      ]);
+      description = firstLineOfBody || subject;
+    }
+    // Otherwise:
+    // Normal commits: The commit subject is the description, and the PR ID is omitted.
+
+    commits.push({ prNumber, description });
+  }
+  return commits;
+}
+
+function getAllChangeDescriptions(changelog) {
+  const releases = changelog.getReleases();
+  const changeDescriptions = Object.values(
+    changelog.getUnreleasedChanges(),
+  ).flat();
+  for (const release of releases) {
+    changeDescriptions.push(
+      ...Object.values(changelog.getReleaseChanges(release.version)).flat(),
+    );
+  }
+  return changeDescriptions;
+}
+
+function getAllLoggedPrNumbers(changelog) {
+  const changeDescriptions = getAllChangeDescriptions(changelog);
+
+  const prNumbersWithChangelogEntries = [];
+  for (const description of changeDescriptions) {
+    const matchResults = description.match(/^\[#(\d+)\]/u);
+    if (matchResults === null) {
+      continue;
+    }
+    const prNumber = matchResults[1];
+    prNumbersWithChangelogEntries.push(prNumber);
+  }
+
+  return prNumbersWithChangelogEntries;
+}
+
+/**
+ * @typedef {import('./constants.js').Version} Version
+ */
+
+/**
+ * Update a changelog with any commits made since the last release. Commits for
+ * PRs that are already included in the changelog are omitted.
+ * @param {Object} options
+ * @param {string} options.changelogContent - The current changelog
+ * @param {Version} options.currentVersion - The current version
+ * @param {string} options.repoUrl - The GitHub repository URL for the current
+ *   project.
+ * @param {boolean} options.isReleaseCandidate - Denotes whether the current
+ *   project is in the midst of release preparation or not. If this is set, any
+ *   new changes are listed under the current release header. Otherwise, they
+ *   are listed under the 'Unreleased' section.
+ * @returns
+ */
+async function updateChangelog({
+  changelogContent,
+  currentVersion,
+  repoUrl,
+  isReleaseCandidate,
+}) {
+  const changelog = parseChangelog({ changelogContent, repoUrl });
+
+  // Ensure we have all tags on remote
+  await runCommand('git', ['fetch', '--tags']);
+  const mostRecentTag = await getMostRecentTag();
+  const commitsHashesSinceLastRelease = await runCommand('git', [
+    'rev-list',
+    `${mostRecentTag}..HEAD`,
+  ]);
+  const commits = await getCommits(commitsHashesSinceLastRelease);
+
+  const loggedPrNumbers = getAllLoggedPrNumbers(changelog);
+  const newCommits = commits.filter(
+    ({ prNumber }) => !loggedPrNumbers.includes(prNumber),
+  );
+
+  const hasUnreleasedChanges = changelog.getUnreleasedChanges().length !== 0;
+  if (
+    newCommits.length === 0 &&
+    (!isReleaseCandidate || hasUnreleasedChanges)
+  ) {
+    return undefined;
+  }
+
+  // Ensure release header exists, if necessary
+  if (
+    isReleaseCandidate &&
+    !changelog
+      .getReleases()
+      .find((release) => release.version === currentVersion)
+  ) {
+    changelog.addRelease({ version: currentVersion });
+  }
+
+  if (isReleaseCandidate && hasUnreleasedChanges) {
+    changelog.migrateUnreleasedChangesToRelease(currentVersion);
+  }
+
+  const newChangeEntries = newCommits.map(({ prNumber, description }) => {
+    if (prNumber) {
+      const prefix = `[#${prNumber}](${repoUrl}/pull/${prNumber})`;
+      return `${prefix}: ${description}`;
+    }
+    return description;
+  });
+
+  for (const description of newChangeEntries.reverse()) {
+    changelog.addChange({
+      version: isReleaseCandidate ? currentVersion : undefined,
+      category: changeCategories.Uncategorized,
+      description,
+    });
+  }
+
+  return changelog.toString();
+}
+
+module.exports = { updateChangelog };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,7 +1243,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -3844,7 +3844,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1:
+semver@^7.2.1, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
This script has been migrated from the [`metamask-extension` repo](https://github.com/MetaMask/metamask-extension/blob/0dbd678f393ae141d207e35b0132e2ee8cb118e9/development/auto-changelog.js). Functionally it should behave almost identically. The differences are:

* It now gets the current version from [the `npm_package_version` environment variable](https://docs.npmjs.com/cli/v6/using-npm/scripts#packagejson-vars) instead of from the hard-coded path to the MetaMask extension manifest.
* The `CHANGELOG.md` file is now read from the current directory where the script is run, rather than from the hard-coded path to the `CHANGELOG.md` file in this repository.
* The repository URL is taken from the `npm_package_repository_url` environment variable instead of being hard-coded.

These changes can all be seen in `src/cli.js`, which is the equivalent to the top-level script in the `metamask-extension` repo, `auto-changelog.js`.

These things will all be made more configurable in future PRs.

A mostly-empty `CHANGELOG.md` file has been added as well. It doesn't quite work with the `update-changelog` script yet, because it wasn't meant to accommodate packages with no releases. But it was enough to make it not completely blow up.

One silly test has been added to allow CI to pass without removing tests altogether. This will be improved in future PRs.

The package has one exported function, `updateChangelog`, to allow the changelog to be updated programmatically.