### PR TITLE
Allow updating changelog when there are no tags

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -67,6 +67,7 @@ function stringifyLinkReferenceDefinitions(repoUrl, releases) {
   const orderedReleases = releases
     .map(({ version }) => version)
     .sort((a, b) => semver.gt(a, b));
+  const hasReleases = orderedReleases.length > 0;
 
   // The "Unreleased" section represents all changes made since the *highest*
   // release, not the most recent release. This is to accomodate patch releases
@@ -75,11 +76,14 @@ function stringifyLinkReferenceDefinitions(repoUrl, releases) {
   // For example, if a library has a v2.0.0 but the v1.0.0 release needed a
   // security update, the v1.0.1 release would then be the most recent, but the
   // range of unreleased changes would remain `v2.0.0...HEAD`.
-  const unreleasedLinkReferenceDefinition = `[${unreleased}]: ${getCompareUrl(
-    repoUrl,
-    `v${orderedReleases[0]}`,
-    'HEAD',
-  )}`;
+  //
+  // If there have not been any releases yet, the repo URL is used directly as
+  // the link definition.
+  const unreleasedLinkReferenceDefinition = `[${unreleased}]: ${
+    hasReleases
+      ? getCompareUrl(repoUrl, `v${orderedReleases[0]}`, 'HEAD')
+      : withTrailingSlash(repoUrl)
+  }`;
 
   // The "previous" release that should be used for comparison is not always
   // the most recent release chronologically. The _highest_ version that is

--- a/src/changelog.test.js
+++ b/src/changelog.test.js
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: fake://metamask.io/compare/vundefined...HEAD
+[Unreleased]: fake://metamask.io/
 `;
 
 describe('Changelog', () => {

--- a/src/updateChangelog.js
+++ b/src/updateChangelog.js
@@ -4,11 +4,15 @@ const { parseChangelog } = require('./parseChangelog');
 const { changeCategories } = require('./constants');
 
 async function getMostRecentTag() {
-  const [mostRecentTagCommitHash] = await runCommand('git', [
+  const results = await runCommand('git', [
     'rev-list',
     '--tags',
     '--max-count=1',
   ]);
+  if (results.length === 0) {
+    return null;
+  }
+  const [mostRecentTagCommitHash] = results;
   const [mostRecentTag] = await runCommand('git', [
     'describe',
     '--tags',
@@ -116,9 +120,12 @@ async function updateChangelog({
   // Ensure we have all tags on remote
   await runCommand('git', ['fetch', '--tags']);
   const mostRecentTag = await getMostRecentTag();
+
+  const commitRange =
+    mostRecentTag === null ? 'HEAD' : `${mostRecentTag}..HEAD`;
   const commitsHashesSinceLastRelease = await runCommand('git', [
     'rev-list',
-    `${mostRecentTag}..HEAD`,
+    commitRange,
   ]);
   const commits = await getCommits(commitsHashesSinceLastRelease);
 


### PR DESCRIPTION
The changelog can now be updated even when there are no tags. Previously it would break in `updateChangelog` when there was no most recent tag, and if you got past that it would put `vundefined` in the link definition for the "Unreleased" header. Now it is tolerant of there being no tags, and the repo URL is used for the link definition of the "Unreleased" header if there is no release to compare to.

Fixes #13