### PR TITLE
Move `update` to sub-command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ or
 
 To update the 'Unreleased' section of the changelog:
 
-`npx @metamask/auto-changelog `
+`npx @metamask/auto-changelog update`
 
 To update the current release section of the changelog:
 
-`npx @metamask/auto-changelog --rc`
+`npx @metamask/auto-changelog update --rc`
 
 ## API Usage
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:json": "prettier '**/*.json' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:json --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:json --write",
-    "update-changelog": "node ./src/cli.js"
+    "changelog": "node ./src/cli.js"
   },
   "dependencies": {
     "cross-spawn": "^7.0.3",

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,7 @@ const { hideBin } = require('yargs/helpers');
 const { updateChangelog } = require('./updateChangelog');
 const { unreleased } = require('./constants');
 
-const epilog = `New commits will be added to the "${unreleased}" section (or \
+const updateEpilog = `New commits will be added to the "${unreleased}" section (or \
 to the section for the current release if the '--rc' flag is used) in reverse \
 chronological order. Any commits for PRs that are represented already in the \
 changelog will be ignored.
@@ -23,17 +23,24 @@ const npmPackageRepositoryUrl = process.env.npm_package_repository_url;
 
 async function main() {
   const { argv } = yargs(hideBin(process.argv))
-    .option('rc', {
-      default: false,
-      description: `Add new changes to the current release header, rather than to the '${unreleased}' section.`,
-      type: 'boolean',
-    })
+    .command(
+      'update',
+      'Update CHANGELOG.md with any changes made since the most recent release.\nUsage: $0 update [options]',
+      (_yargs) =>
+        _yargs
+          .option('rc', {
+            default: false,
+            description: `Add new changes to the current release header, rather than to the '${unreleased}' section.`,
+            type: 'boolean',
+          })
+          .epilog(updateEpilog),
+    )
     .strict()
+    .demandCommand()
     .help('help')
     .usage(
-      `Update CHANGELOG.md with any changes made since the most recent release.\nUsage: $0 [options]`,
-    )
-    .epilog(epilog);
+      `Utilities for validating and updating "Keep a Changelog" formatted changelogs.\nUsage: $0 [command] [options]`,
+    );
 
   if (!npmPackageVersion) {
     console.error(


### PR DESCRIPTION
The "update" action has been moved to a sub-command, in preparation for adding more commands in later PRs. Specifying a command has been made mandatory.

The `update-changelog` npm script has been renamed to `changelog`, to reflect that it will soon be used for more than just updates.