### PR TITLE
Remove accidental test description for `help`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -29,7 +29,7 @@ async function main() {
       type: 'boolean',
     })
     .strict()
-    .help('help', 'test')
+    .help('help')
     .usage(
       `Update CHANGELOG.md with any changes made since the most recent release.\nUsage: $0 [options]`,
     )


### PR DESCRIPTION
The description `test` was added for the `help` command when converting the CLI to use yargs. This description was accidentally left in and committed as part of #21.