### PR TITLE
Fix release header sorting

### DIFF
--- a/src/changelog.js
+++ b/src/changelog.js
@@ -64,9 +64,12 @@ function getTagUrl(repoUrl, tag) {
 }
 
 function stringifyLinkReferenceDefinitions(repoUrl, releases) {
-  const orderedReleases = releases
+  const releasesOrderedByVersion = releases
     .map(({ version }) => version)
-    .sort((a, b) => semver.gt(a, b));
+    .sort((a, b) => {
+      return semver.gt(a, b) ? -1 : 1;
+    });
+  const orderedReleases = releases.map(({ version }) => version);
   const hasReleases = orderedReleases.length > 0;
 
   // The "Unreleased" section represents all changes made since the *highest*
@@ -81,7 +84,7 @@ function stringifyLinkReferenceDefinitions(repoUrl, releases) {
   // the link definition.
   const unreleasedLinkReferenceDefinition = `[${unreleased}]: ${
     hasReleases
-      ? getCompareUrl(repoUrl, `v${orderedReleases[0]}`, 'HEAD')
+      ? getCompareUrl(repoUrl, `v${releasesOrderedByVersion[0]}`, 'HEAD')
       : withTrailingSlash(repoUrl)
   }`;
 


### PR DESCRIPTION
The release header sorting was broken in two ways. First, the sort function was totally broken - it returned a boolean instead of the expected `-1` or `1`. Second, the release link generation would always consider the _numerical_ previous release to be the previous release for comparison purposes, even if it was released _after_.

The sorting function now correctly returns numbers, as `Array.prototype.sort` expects. The release link logic has been updated to ensure the "previous" release is both numerically and chronologically previous as well.

We don't yet validate that the releases are sorted chronologically, but that is the assumption for now. We can add validation using release dates at some point in the future.