### PR TITLE
Allow configuring 'currentVersion'

### DIFF
--- a/src/updateChangelog.js
+++ b/src/updateChangelog.js
@@ -100,7 +100,8 @@ function getAllLoggedPrNumbers(changelog) {
  * PRs that are already included in the changelog are omitted.
  * @param {Object} options
  * @param {string} options.changelogContent - The current changelog
- * @param {Version} options.currentVersion - The current version
+ * @param {Version} [options.currentVersion] - The current version. Required if
+ *   `isReleaseCandidate` is set, but optional otherwise.
  * @param {string} options.repoUrl - The GitHub repository URL for the current
  *   project.
  * @param {boolean} options.isReleaseCandidate - Denotes whether the current
@@ -115,6 +116,11 @@ async function updateChangelog({
   repoUrl,
   isReleaseCandidate,
 }) {
+  if (isReleaseCandidate && !currentVersion) {
+    throw new Error(
+      `A version must be specified if 'isReleaseCandidate' is set.`,
+    );
+  }
   const changelog = parseChangelog({ changelogContent, repoUrl });
 
   // Ensure we have all tags on remote


### PR DESCRIPTION
Rather than always obtaining the 'currentVersion' of the project from an environment variable, it can now be passed in via a CLI flag instead.

Additionally, the validation for the version has been improved. It will now throw if the current version isn't a valid SemVer version, as our update logic depends upon it being valid. We also now ensure that the error message for a messing version is only printed when it was strictly required (it wasn't used for non-RC updates), and that the script terminates at that point.

Closes #10