### PR TITLE
Collect coverage metrics for all files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.js', '!\\.test\\.js$'],
   coverageReporters: ['text', 'html'],
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   testEnvironment: 'node',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.js', '!\\.test\\.js$'],
+  collectCoverageFrom: ['src/**/*\\.js'],
   coverageReporters: ['text', 'html'],
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   testEnvironment: 'node',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*\\.js'],
+  collectCoverageFrom: ['src/**/*.js'],
   coverageReporters: ['text', 'html'],
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   testEnvironment: 'node',


### PR DESCRIPTION
We now collect coverage metrics for all files, rather than just those executed by tests.