### PR TITLE
Fix Unreleased changes detection

### DIFF
--- a/src/validateChangelog.js
+++ b/src/validateChangelog.js
@@ -88,7 +88,8 @@ function validateChangelog({
     throw new MissingCurrentVersionError(currentVersion);
   }
 
-  const hasUnreleasedChanges = changelog.getUnreleasedChanges().length !== 0;
+  const hasUnreleasedChanges =
+    Object.keys(changelog.getUnreleasedChanges()).length !== 0;
   if (isReleaseCandidate && hasUnreleasedChanges) {
     throw new UnreleasedChangesError();
   }

--- a/src/validateChangelog.test.js
+++ b/src/validateChangelog.test.js
@@ -416,6 +416,18 @@ describe('validateChangelog', () => {
   });
 
   describe('is a release candidate', () => {
+    it('should not throw for a valid changelog with multiple releases', () => {
+      expect(() =>
+        validateChangelog({
+          changelogContent: changelogWithReleases,
+          currentVersion: '1.0.0',
+          repoUrl:
+            'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+          isReleaseCandidate: true,
+        }),
+      ).not.toThrow();
+    });
+
     it('should throw if the current version release header is missing', () => {
       expect(() =>
         validateChangelog({


### PR DESCRIPTION
The command `auto-changelog validate --rc` would always fail claiming that there were Unreleased changes, even when there were none. This has been fixed, and a test has been added to capture this case.