### PR TITLE
Throw error if current version tag exists when updating

### DIFF
--- a/src/updateChangelog.js
+++ b/src/updateChangelog.js
@@ -140,6 +140,12 @@ async function updateChangelog({
   await runCommand('git', ['fetch', '--tags']);
   const mostRecentTag = await getMostRecentTag({ projectRootDirectory });
 
+  if (isReleaseCandidate && mostRecentTag === currentVersion) {
+    throw new Error(
+      `Current version already has tag, which is unexpected for a release candidate.`,
+    );
+  }
+
   const commitRange =
     mostRecentTag === null ? 'HEAD' : `${mostRecentTag}..HEAD`;
   const commitsHashesSinceLastRelease = await getCommitHashesInRange(


### PR DESCRIPTION
We now throw an error if the current version already has a tag when updating the changelog. This helps protect users from accidentally updating the changelog before bumping the version.

Fixes #51