### PR TITLE
Fix mistaking newline between categories as part of change entry

### DIFF
--- a/src/parseChangelog.js
+++ b/src/parseChangelog.js
@@ -94,7 +94,8 @@ function parseChangelog({ changelogContent, repoUrl }) {
       if (results === null) {
         throw new Error(`Malformed category header: '${truncated(line)}'`);
       }
-      finalizePreviousChange();
+      const isFirstCategory = mostRecentCategory === null;
+      finalizePreviousChange({ removeTrailingNewline: !isFirstCategory });
       mostRecentCategory = results[1];
     } else if (line.startsWith('- ')) {
       if (mostRecentCategory === undefined) {

--- a/src/parseChangelog.test.js
+++ b/src/parseChangelog.test.js
@@ -281,6 +281,72 @@ describe('parseChangelog', () => {
     });
   });
 
+  it('should not mistake newline between sections as part of change entry', () => {
+    const changelog = parseChangelog({
+      changelogContent: outdent`
+        # Changelog
+        All notable changes to this project will be documented in this file.
+
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+        ## [Unreleased]
+
+        ## [1.0.0] - 2020-01-01
+        ### Changed
+        - Something else
+          - Further explanation of changes
+
+        ### Fixed
+        - Not including newline between change categories as part of change entry
+
+        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        `,
+      repoUrl:
+        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+    });
+
+    expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+      Changed: ['Something else\n  - Further explanation of changes'],
+      Fixed: [
+        'Not including newline between change categories as part of change entry',
+      ],
+    });
+  });
+
+  it('should not mistake newline between releases as part of change entry', () => {
+    const changelog = parseChangelog({
+      changelogContent: outdent`
+        # Changelog
+        All notable changes to this project will be documented in this file.
+
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+        ## [Unreleased]
+
+        ## [1.0.0] - 2020-01-01
+        ### Changed
+        - Something else
+          - Further explanation of changes
+
+        ## [0.0.1] - 2020-01-01
+        ### Changed
+        - Initial release
+
+        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        `,
+      repoUrl:
+        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+    });
+
+    expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+      Changed: ['Something else\n  - Further explanation of changes'],
+    });
+  });
+
   it('should parse changelog missing newlines between sections', () => {
     const changelog = parseChangelog({
       changelogContent: outdent`


### PR DESCRIPTION
Our `parseChangelog` function was mistakenly interpreting newlines between change categories as part of the change entry. Now it does not.

A new test has been added for this fix, along with a second one to verify that we're treating the newline between releases appropriately as well (this was working already but wasn't tested).