### PR TITLE
Fix tag and version equality check

### DIFF
--- a/src/updateChangelog.js
+++ b/src/updateChangelog.js
@@ -140,7 +140,7 @@ async function updateChangelog({
   await runCommand('git', ['fetch', '--tags']);
   const mostRecentTag = await getMostRecentTag({ projectRootDirectory });
 
-  if (isReleaseCandidate && mostRecentTag === currentVersion) {
+  if (isReleaseCandidate && mostRecentTag === `v${currentVersion}`) {
     throw new Error(
       `Current version already has tag, which is unexpected for a release candidate.`,
     );


### PR DESCRIPTION
This PR fixes some faulty input validation in `updateChangelog`, which performed a strict equality check between a plain version string (e.g. `1.0.0`) and a version tag (e.g. `v1.0.0`), and would therefore always return `false`.