### PR TITLE
Validate change category during parsing

### DIFF
--- a/src/parseChangelog.test.ts
+++ b/src/parseChangelog.test.ts
@@ -542,7 +542,7 @@ describe('parseChangelog', () => {
     ).toThrow(`Unrecognized line: '#### Changed'`);
   });
 
-  it('should throw if a change category is unrecognized', () => {
+  it('should throw if a change category is malformed', () => {
     const brokenChangelog = outdent`
       # Changelog
       All notable changes to this project will be documented in this file.
@@ -566,6 +566,32 @@ describe('parseChangelog', () => {
           'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
       }),
     ).toThrow(`Malformed category header: '### Ch-Ch-Ch-Ch-Changes'`);
+  });
+
+  it('should throw if a change category is unrecognized', () => {
+    const brokenChangelog = outdent`
+      # Changelog
+      All notable changes to this project will be documented in this file.
+
+      The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+      and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+      ## [Unreleased]
+
+      ## [1.0.0] - 2020-01-01
+      ### Invalid
+      - Something else
+
+      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      `;
+    expect(() =>
+      parseChangelog({
+        changelogContent: brokenChangelog,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      }),
+    ).toThrow(`Invalid change category: 'Invalid'`);
   });
 
   it('should throw if a change starts with the wrong prefix', () => {

--- a/src/parseChangelog.ts
+++ b/src/parseChangelog.ts
@@ -1,16 +1,12 @@
 import Changelog from './changelog';
-import {
-  ChangeCategory,
-  orderedChangeCategories,
-  unreleased,
-} from './constants';
+import { ChangeCategory, unreleased } from './constants';
 
 function truncated(line: string) {
   return line.length > 80 ? `${line.slice(0, 80)}...` : line;
 }
 
 function isValidChangeCategory(category: string): category is ChangeCategory {
-  return orderedChangeCategories.includes(category as ChangeCategory);
+  return ChangeCategory[category as ChangeCategory] !== undefined;
 }
 
 /**

--- a/src/parseChangelog.ts
+++ b/src/parseChangelog.ts
@@ -1,8 +1,16 @@
 import Changelog from './changelog';
-import { ChangeCategory, unreleased } from './constants';
+import {
+  ChangeCategory,
+  orderedChangeCategories,
+  unreleased,
+} from './constants';
 
 function truncated(line: string) {
   return line.length > 80 ? `${line.slice(0, 80)}...` : line;
+}
+
+function isValidChangeCategory(category: string): category is ChangeCategory {
+  return orderedChangeCategories.includes(category as ChangeCategory);
 }
 
 /**
@@ -112,8 +120,10 @@ export function parseChangelog({
       finalizePreviousChange({
         removeTrailingNewline: !isFirstCategory,
       });
-      // TODO: Throw an error if results[1] is not a valid ChangeCategory.
-      mostRecentCategory = results[1] as ChangeCategory;
+      if (!isValidChangeCategory(results[1])) {
+        throw new Error(`Invalid change category: '${results[1]}'`);
+      }
+      mostRecentCategory = results[1];
     } else if (line.startsWith('- ')) {
       if (!mostRecentCategory) {
         throw new Error(`Category missing for change: '${truncated(line)}'`);

--- a/src/validateChangelog.test.ts
+++ b/src/validateChangelog.test.ts
@@ -207,7 +207,7 @@ describe('validateChangelog', () => {
           'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
         isReleaseCandidate: false,
       }),
-    ).toThrow(`Unrecognized category: 'Updated'`);
+    ).toThrow(`Invalid change category: 'Updated'`);
   });
 
   it('should throw when the Unreleased section is missing', () => {


### PR DESCRIPTION
The change category is now validated as part of `parseChangelog`. Previously it was still being validated, but not until later on when the change categories were added to a `Changelog` instance. Validating it earlier in `parseChangelog` makes more sense now that we have types.