### PR TITLE
Replace TODO comment about missing test case

### DIFF
--- a/src/parseChangelog.ts
+++ b/src/parseChangelog.ts
@@ -60,8 +60,9 @@ export function parseChangelog({
     if (!currentChangeEntry) {
       return;
     }
-    // TODO: This could possibly happen two successive, empty change categories/releases.
-    /* istanbul ignore next: This doesn't happen in practice. */
+    // This should never happen in practice, because `mostRecentCategory` is
+    // guaranteed to be set if `currentChangeEntry` is set.
+    /* istanbul ignore next */
     if (!mostRecentCategory) {
       throw new Error('Cannot finalize change without most recent category.');
     }


### PR DESCRIPTION
The issue identified by this TODO comment did not exist after all. It has been replaced with a longer comment that explains why the following error is never encountered.