### PR TITLE
Move PR to end of change entry

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -203,8 +203,8 @@ export async function updateChangelog({
 
   const newChangeEntries = newCommits.map(({ prNumber, description }) => {
     if (prNumber) {
-      const prefix = `[#${prNumber}](${repoUrl}/pull/${prNumber})`;
-      return `${prefix}: ${description}`;
+      const suffix = `([#${prNumber}](${repoUrl}/pull/${prNumber}))`;
+      return `${description} ${suffix}`;
     }
     return description;
   });


### PR DESCRIPTION
The PR associated with a change has been moved to the end of the change entry, rather than being used as the prefix. This matches the "Keep A Changelog" style better, and generally makes the changelog easier to read. It also makes it easier to handle the case where one change was related to multiple PRs.