### PR TITLE
Update cli-related package.json scripts, fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "access": "public"
   },
   "main": "dist/index.js",
-  "bin": "dist/cli.js",
+  "bin": {
+    "@metamask/auto-changelog": "dist/cli.js",
+    "auto-changelog": "dist/cli.js"
+  },
   "engines": {
     "node": ">=12.0.0"
   },
@@ -26,8 +29,8 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "build": "tsc --project .",
-    "changelog": "node ./src/cli.js"
+    "build": "tsc --project . && chmod +x 'dist/cli.js'",
+    "changelog": "./dist/cli.js"
   },
   "dependencies": {
     "cross-spawn": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "access": "public"
   },
   "main": "dist/index.js",
-  "bin": {
-    "@metamask/auto-changelog": "dist/cli.js",
-    "auto-changelog": "dist/cli.js"
-  },
+  "bin": "dist/cli.js",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepublishOnly": "yarn lint && yarn test",
+    "prepublishOnly": "yarn build && chmod +x dist/cli.js && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "build": "tsc --project . && chmod +x 'dist/cli.js'",
-    "changelog": "./dist/cli.js"
+    "build": "tsc --project .",
+    "changelog": "node dist/cli.js"
   },
   "dependencies": {
     "cross-spawn": "^7.0.3",


### PR DESCRIPTION
Executing the CLI directly by invoking `./dist/cli.js` wasn't working because we never called `chmod +x` on it. This PR adds a call to `chmod` to the `build` package script.

In addition, it updates the package.json `bin` field to register two names for the application, `@metamask/auto-changelog` and `auto-changelog`. Previously, only the former (i.e. the name of the package) would be usable.