### PR TITLE
Fix updateChangelog PR number handling

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -37,18 +37,18 @@ async function getCommits(commitHashes: string[]) {
       commitHash,
     ]);
 
-    let matchResults = subject.match(/\(#\d+\)/u);
+    let matchResults = subject.match(/\(#(\d+)\)/u);
     let prNumber: string | undefined;
     let description = subject;
 
-    // Squash & Merge: the commit subject is parsed as `<description> (#<PR ID>)`
     if (matchResults) {
+      // Squash & Merge: the commit subject is parsed as `<description> (#<PR ID>)`
       prNumber = matchResults[1];
       description = subject.match(/^(.+)\s\(#\d+\)/u)?.[1] || '';
+    } else {
       // Merge: the PR ID is parsed from the git subject (which is of the form `Merge pull request
       // #<PR ID> from <branch>`, and the description is assumed to be the first line of the body.
       // If no body is found, the description is set to the commit subject
-    } else {
       matchResults = subject.match(/#(\d+)\sfrom/u);
       if (matchResults) {
         prNumber = matchResults[1];


### PR DESCRIPTION
I accidentally introduced an error in #59, by failing to notice that some RegEx literals I moved around were not identical. Specifically, there was a capturing group around a `\d+` in one of the original literals but not the other. Compare these two lines: https://github.com/MetaMask/auto-changelog/blob/9c018fb8b98a40aaa0da1c08f4576b178d27c932/src/updateChangelog.js#L39-L40

This PR ensures that PR numbers are properly captured.