### PR TITLE
Add build:clean script, use in prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepublishOnly": "yarn build && chmod +x dist/cli.js && yarn lint && yarn test",
+    "prepublishOnly": "yarn build:clean && chmod +x dist/cli.js && yarn lint && yarn test",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
+    "build:clean": "rimraf dist && yarn build",
     "build": "tsc --project .",
     "changelog": "node dist/cli.js"
   },
@@ -56,6 +57,7 @@
     "jest": "^26.4.2",
     "outdent": "^0.8.0",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "ts-jest": "^26.5.6",
     "typescript": "^4.2.4"
   }


### PR DESCRIPTION
This will prevent us from publishing unused files. The is implemented per the module template. Uses `rimraf`.