### PR TITLE
Add Changelog.getStringifiedRelease

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -203,7 +203,7 @@ export default class Changelog {
   }
 
   /**
-   * Add a release to the changelog
+   * Add a release to the changelog.
    *
    * @param options
    * @param options.addToStart - Determines whether the change is added to the
@@ -236,7 +236,7 @@ export default class Changelog {
   }
 
   /**
-   * Add a change to the changelog
+   * Add a change to the changelog.
    *
    * @param options
    * @param options.addToStart - Determines whether the change is added to the
@@ -286,8 +286,7 @@ export default class Changelog {
    * Changes are migrated in their existing categories, and placed above any
    * pre-existing changes in that category.
    *
-   * @param version - The release version to migrate unreleased
-   * changes to.
+   * @param version - The release version to migrate unreleased changes to.
    */
   migrateUnreleasedChangesToRelease(version: Version) {
     const releaseChanges = this._changes[version];
@@ -312,6 +311,7 @@ export default class Changelog {
 
   /**
    * Gets the metadata for all releases.
+   *
    * @returns The metadata for each release.
    */
   getReleases() {
@@ -319,7 +319,36 @@ export default class Changelog {
   }
 
   /**
+   * Gets the release of the given version.
+   *
+   * @param version - The version of the release to retrieve.
+   * @returns The specified release, or undefined if no such release exists.
+   */
+  getRelease(version: Version) {
+    return this.getReleases().find(
+      ({ version: _version }) => _version === version,
+    );
+  }
+
+  /**
+   * Gets the stringified release of the given version.
+   * Throws an error if no such release exists.
+   *
+   * @param version - The version of the release to stringify.
+   * @returns The stringified release, as it appears in the changelog.
+   */
+  getStringifiedRelease(version: Version) {
+    const release = this.getRelease(version);
+    if (!release) {
+      throw new Error(`Specified release version does not exist: '${version}'`);
+    }
+    const releaseChanges = this.getReleaseChanges(version);
+    return stringifyRelease(version, releaseChanges, release);
+  }
+
+  /**
    * Gets the changes in the given release, organized by category.
+   *
    * @param version - The version of the release being retrieved.
    * @returns The changes included in the given released.
    */
@@ -329,6 +358,7 @@ export default class Changelog {
 
   /**
    * Gets all changes that have not yet been released
+   *
    * @returns The changes that have not yet been released.
    */
   getUnreleasedChanges() {
@@ -337,6 +367,7 @@ export default class Changelog {
 
   /**
    * The stringified changelog, formatted according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+   *
    * @returns The stringified changelog.
    */
   toString() {

--- a/src/parse-changelog.test.ts
+++ b/src/parse-changelog.test.ts
@@ -108,6 +108,19 @@ describe('parseChangelog', () => {
     expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
       Changed: ['Something'],
     });
+    expect(changelog.getRelease('1.0.0')).toStrictEqual({
+      date: '2020-01-01',
+      status: undefined,
+      version: '1.0.0',
+    });
+    expect(changelog.getStringifiedRelease('1.0.0')).toStrictEqual(outdent`
+    ## [1.0.0] - 2020-01-01
+    ### Changed
+    - Something else`);
+    expect(changelog.getRelease('2.0.0')).toBeUndefined();
+    expect(() => changelog.getStringifiedRelease('2.0.0')).toThrow(
+      "Specified release version does not exist: '2.0.0'",
+    );
     expect(changelog.getUnreleasedChanges()).toStrictEqual({});
   });
 


### PR DESCRIPTION
Adds two new methods `getRelease` and `getStringifiedRelease` to the `Changelog` class. This will allow us to retrieve changelog bodies to the bodies of release pull requests and/or GitHub releases in our GitHub Actions.