### PR TITLE
Remove trailing '.git' from default repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/MetaMask/auto-changelog"
+    "url": "https://github.com/MetaMask/auto-changelog.git"
   },
   "scripts": {
     "test": "jest",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,10 @@ const npmPackageVersion = process.env.npm_package_version;
 // eslint-disable-next-line node/no-process-env
 const npmPackageRepositoryUrl = process.env.npm_package_repository_url;
 
+const githubRepositoryUrl = npmPackageRepositoryUrl
+  ? npmPackageRepositoryUrl.replace(/\.git$/u, '')
+  : null;
+
 function isValidUrl(proposedUrl: string) {
   try {
     // eslint-disable-next-line no-new
@@ -152,7 +156,7 @@ function configureCommonCommandOptions(_yargs: Argv) {
       type: 'string',
     })
     .option('repo', {
-      default: npmPackageRepositoryUrl,
+      default: githubRepositoryUrl,
       description: `The GitHub repository URL`,
       type: 'string',
     })


### PR DESCRIPTION
If no `repo` parameter is supplied we get the GitHub repository URL from the environment variable `npm_package_repository_url`, which is set to the git repository URL if the `repository` field of `package.json` is set.

However, the git repository URL is not the same as the GitHub repository URL. The git repository URL ends with `.git`, but the GitHub repository URL does not. This discrepency wasn't noticed at first because the `repository` field in the `package.json` file for this project is malformed (the `.git` is missing).

The CLI has been updated to remove this extraneous `.git`, if it's present. So how the CLI will work whether the trailing `.git` is there or not. The `repository` entry for this project has been fixed as well.