### PR TITLE
Fix changelog where first release isn't first

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -109,13 +109,16 @@ function stringifyLinkReferenceDefinitions(
   repoUrl: string,
   releases: ReleaseMetadata[],
 ) {
-  const releasesOrderedByVersion = releases
+  // A list of release versions in descending SemVer order
+  const descendingSemverVersions = releases
     .map(({ version }) => version)
     .sort((a: Version, b: Version) => {
       return semver.gt(a, b) ? -1 : 1;
     });
-  const orderedReleases = releases.map(({ version }) => version);
-  const hasReleases = orderedReleases.length > 0;
+  const latestSemverVersion = descendingSemverVersions[0];
+  // A list of release versions in chronological order
+  const chronologicalVersions = releases.map(({ version }) => version);
+  const hasReleases = chronologicalVersions.length > 0;
 
   // The "Unreleased" section represents all changes made since the *highest*
   // release, not the most recent release. This is to accomodate patch releases
@@ -129,7 +132,7 @@ function stringifyLinkReferenceDefinitions(
   // the link definition.
   const unreleasedLinkReferenceDefinition = `[${unreleased}]: ${
     hasReleases
-      ? getCompareUrl(repoUrl, `v${releasesOrderedByVersion[0]}`, 'HEAD')
+      ? getCompareUrl(repoUrl, `v${latestSemverVersion}`, 'HEAD')
       : withTrailingSlash(repoUrl)
   }`;
 
@@ -140,11 +143,11 @@ function stringifyLinkReferenceDefinitions(
   const releaseLinkReferenceDefinitions = releases
     .map(({ version }) => {
       let diffUrl;
-      if (version === orderedReleases[orderedReleases.length - 1]) {
+      if (version === chronologicalVersions[chronologicalVersions.length - 1]) {
         diffUrl = getTagUrl(repoUrl, `v${version}`);
       } else {
-        const versionIndex = orderedReleases.indexOf(version);
-        const previousVersion = orderedReleases
+        const versionIndex = chronologicalVersions.indexOf(version);
+        const previousVersion = chronologicalVersions
           .slice(versionIndex)
           .find((releaseVersion: Version) => {
             return semver.gt(version, releaseVersion);

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -139,20 +139,21 @@ function stringifyLinkReferenceDefinitions(
   // patch releases on older releases can be accomodated.
   const releaseLinkReferenceDefinitions = releases
     .map(({ version }) => {
+      let diffUrl;
       if (version === orderedReleases[orderedReleases.length - 1]) {
-        return `[${version}]: ${getTagUrl(repoUrl, `v${version}`)}`;
+        diffUrl = getTagUrl(repoUrl, `v${version}`);
+      } else {
+        const versionIndex = orderedReleases.indexOf(version);
+        const previousVersion = orderedReleases
+          .slice(versionIndex)
+          .find((releaseVersion: Version) => {
+            return semver.gt(version, releaseVersion);
+          });
+        diffUrl = previousVersion
+          ? getCompareUrl(repoUrl, `v${previousVersion}`, `v${version}`)
+          : getTagUrl(repoUrl, `v${version}`);
       }
-      const versionIndex = orderedReleases.indexOf(version);
-      const previousVersion = orderedReleases
-        .slice(versionIndex)
-        .find((releaseVersion: Version) => {
-          return semver.gt(version, releaseVersion);
-        });
-      return `[${version}]: ${getCompareUrl(
-        repoUrl,
-        `v${previousVersion}`,
-        `v${version}`,
-      )}`;
+      return `[${version}]: ${diffUrl}`;
     })
     .join('\n');
   return `${unreleasedLinkReferenceDefinition}\n${releaseLinkReferenceDefinitions}${

--- a/src/validate-changelog.test.ts
+++ b/src/validate-changelog.test.ts
@@ -68,6 +68,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
 `;
 
+const backportChangelog = `# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.3] - 2020-01-01
+### Fixed
+- Security fix
+
+## [0.0.2] - 2020-01-01
+### Fixed
+- Something
+
+## [1.0.0] - 2020-01-01
+### Changed
+- Something else
+
+[Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+[0.0.3]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.2
+[1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+`;
+
 describe('validateChangelog', () => {
   it('should not throw for any empty valid changelog', () => {
     expect(() =>
@@ -97,6 +123,18 @@ describe('validateChangelog', () => {
     expect(() =>
       validateChangelog({
         changelogContent: branchingChangelog,
+        currentVersion: '1.0.0',
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        isReleaseCandidate: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it('should not throw when the first release is not the first numerically', () => {
+    expect(() =>
+      validateChangelog({
+        changelogContent: backportChangelog,
         currentVersion: '1.0.0',
         repoUrl:
           'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',


### PR DESCRIPTION
`auto-changelog` will now correctly update and validate changelogs where the first release chronologically is different than the first release numerically.

A test has been added to ensure such a changelog is now validated correctly. This test fails on `main`.

Fixes #57