### PR TITLE
Add `init` command

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,13 @@
+import Changelog from './changelog';
+
+/**
+ * Creates a new empty changelog.
+ *
+ * @param options
+ * @param options.repoUrl - The GitHub repository URL for the current project.
+ * @returns The initial changelog text.
+ */
+export function createEmptyChangelog({ repoUrl }: { repoUrl: string }) {
+  const changelog = new Changelog({ repoUrl });
+  return changelog.toString();
+}


### PR DESCRIPTION
This command generates an empty changelog. It doesn't list any changes or releases.

Closes #14