### PR TITLE
Validate changelog during CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, and Test
+name: Build, Lint, Test
 
 on:
   push:
@@ -22,11 +22,29 @@ jobs:
       - run: yarn setup:postinstall
       - run: yarn build
       - run: yarn lint
-      - run: yarn test
+      - run: yarn
+  validate-changelog:
+    name: Validate changelog
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js v12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn --frozen-lockfile
+      - run: yarn build
+      - name: Validate RC changelog
+        if: ${{ startsWith(github.ref, 'release-v') }}
+        run: yarn changelog validate --rc
+      - name: Validate changelog
+        if: ${{ !startsWith(github.ref, 'release-v') }}
+        run: yarn changelog validate
   all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-20.04
     needs:
       - build-lint-test
+      - validate-changelog
     steps:
       - run: echo "Great success!"

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -22,7 +22,7 @@ jobs:
       - run: yarn setup:postinstall
       - run: yarn build
       - run: yarn lint
-      - run: yarn
+      - run: yarn test
   validate-changelog:
     name: Validate changelog
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, Test
+name: Build, Lint, and Test
 
 on:
   push:


### PR DESCRIPTION
A "Validate changelog" step has been added to CI to validate the changelog on each PR. It will use the `--rc` flag as well when run on a release branch.