### PR TITLE
Cache npm dependencies

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -18,6 +18,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Get Yarn cache directory
+        run: echo "::set-output name=YARN_CACHE_DIR::$(yarn cache dir)"
+        id: yarn-cache-dir
+      - name: Get Yarn version
+        run: echo "::set-output name=YARN_VERSION::$(yarn --version)"
+        id: yarn-version
+      - name: Cache yarn dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
+          key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - run: yarn setup:postinstall
       - run: yarn build


### PR DESCRIPTION
npm dependencies are now cached between CI runs. If a cache is found that used the same OS, Yarn version, and `yarn.lock` file, it is restored.

The `actions/cache@2` action (provided by GitHub) is used for caching. The way this action works is that it will restore the cache at the specified path if a matching cache is found. If no matching cache is found, it will run the job as normal and cache whatever it finds in that directory at the end of the job.

The Yarn cache directory is cached instead of `node_modules` because it contains the exact tarball that yarn downloaded from the registry, unaffected by post-install scripts. This is particularly important when using the `actions/cache@v2` action, because it can only create a cache at the end of a job. So we need to ensure the cached path is in the desired state at the end of the job.

The cache key includes the OS, Yarn version, and `yarn.lock` hash because those are the factors I know of that can influence what gets downloaded. I had considered including the Node.js version because some dependencies do install differently with different Node.js versions (e.g. native dependencies). But I believe those differences are during the install/post-install step, after the tarball is downloaded. We're only caching the tarballs, which should be the same across all Node.js versions.