### PR TITLE
Fix PR number detection in existing change entries

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -88,7 +88,7 @@ function getAllLoggedPrNumbers(changelog: Changelog) {
   const prNumbersWithChangelogEntries = [];
   for (const description of changeDescriptions) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const matchResults = description!.match(/^\[#(\d+)\]/u);
+    const matchResults = description!.match(/\[#(\d+)\]/u);
     if (matchResults === null) {
       continue;
     }


### PR DESCRIPTION
The `update` command will filter out any commits that are the result of PRs that have been referenced already in the changelog.

Unfortunately this PR number detection only looked at the beginning of the entry. This was because prior to #66, that's where it would be by default (though this was always a poor decision, because it was always possible to update the change entry and reference the PR anywhere). This is especially broken since #66.

We now look for things that look like PR numbers anywhere in the change description.