### PR TITLE
Detect all PRs referenced in each change description

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -88,12 +88,9 @@ function getAllLoggedPrNumbers(changelog: Changelog) {
   const prNumbersWithChangelogEntries = [];
   for (const description of changeDescriptions) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const matchResults = description!.match(/\[#(\d+)\]/u);
-    if (matchResults === null) {
-      continue;
-    }
-    const prNumber = matchResults[1];
-    prNumbersWithChangelogEntries.push(prNumber);
+    const matchResults = description!.matchAll(/\[#(\d+)\]/gu);
+    const prNumbers = Array.from(matchResults, (result) => result[1]);
+    prNumbersWithChangelogEntries.push(...prNumbers);
   }
 
   return prNumbersWithChangelogEntries;


### PR DESCRIPTION
We now detect all referenced PRs in each change description, rather than just the first. This is especially helpful when one change entry references many PRs (e.g. a set of related bug fixes).

Manual testing steps:
- Checkout this branch and run `yarn build`
- Run `yarn changelog update` a few times and observe how the duplicate detection works in the typical case where only one PR is referenced. After running this a few times the changelog should have one copy of each commit with a PR number, but multiple for the commit on this branch which has no number yet.
- Combine all unreleased change entries that include a PR number into a single change entry (e.g. indent them all once, that should do it).
- Run `yarn changelog update` again a few times and observe that the duplication detection still works the same as before.

