### PR TITLE
Add more exports to index.ts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['./src/**.ts'],
+  coveragePathIgnorePatterns: ['/node_modules/', 'index.ts'],
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,9 @@
 module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['./src/**.ts'],
-  coveragePathIgnorePatterns: ['/node_modules/', 'index.ts'],
+  // Jest (i.e. istanbul) identifies every export in index.ts as a distinct
+  // function, which tanks our function coverage.
+  coveragePathIgnorePatterns: ['index.ts'],
   coverageReporters: ['text', 'html'],
   coverageThreshold: {
     global: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export { default as Changelog } from './changelog';
+export { parseChangelog } from './parse-changelog';
 export { updateChangelog } from './update-changelog';
 export {
   ChangelogFormattingError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Changelog } from './changelog';
+export { createEmptyChangelog } from './init';
 export { parseChangelog } from './parse-changelog';
 export { updateChangelog } from './update-changelog';
 export {

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,0 +1,22 @@
+import { createEmptyChangelog } from './init';
+
+const exampleRepoUrl =
+  'https://github.com/ExampleUsernameOrOrganization/ExampleRepository/';
+const emptyChangelog = `# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: ${exampleRepoUrl}
+`;
+
+describe('createEmptyChangelog', () => {
+  it('creates an empty changelog', () => {
+    expect(createEmptyChangelog({ repoUrl: exampleRepoUrl })).toStrictEqual(
+      emptyChangelog,
+    );
+  });
+});


### PR DESCRIPTION
I found myself in a position where I wanted to use `parseChangelog`. While we're here, we might as well export `createEmptyChangelog` and the `Changelog` class, as well. `import type { Changelog }` could be useful in TypeScript projects, for example.