### PR TITLE
Remove projectRootDirectory param from getMostRecentTag

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -4,15 +4,8 @@ import { parseChangelog } from './parse-changelog';
 import { ChangeCategory, Version } from './constants';
 import type Changelog from './changelog';
 
-async function getMostRecentTag({
-  projectRootDirectory,
-}: {
-  projectRootDirectory?: string;
-}) {
+async function getMostRecentTag() {
   const revListArgs = ['rev-list', '--tags', '--max-count=1'];
-  if (projectRootDirectory) {
-    revListArgs.push(projectRootDirectory);
-  }
   const results = await runCommand('git', revListArgs);
   if (results.length === 0) {
     return null;
@@ -149,7 +142,7 @@ export async function updateChangelog({
 
   // Ensure we have all tags on remote
   await runCommand('git', ['fetch', '--tags']);
-  const mostRecentTag = await getMostRecentTag({ projectRootDirectory });
+  const mostRecentTag = await getMostRecentTag();
 
   if (isReleaseCandidate && mostRecentTag === `v${currentVersion}`) {
     throw new Error(


### PR DESCRIPTION
The `projectRootDirectory` param was added to a call to `git rev-list` in `getMostRecentTag`. Per the [`git rev-list` docs](https://git-scm.com/docs/git-rev-list), providing one or more paths to that command will limit the returned lists to commits "modifying the given <paths>". This param is not only unnecessary, but prevents us from retrieving tags belonging to merge commits, because they don't modify anything. The purpose of `getMostRecentTag` is to get the most recent tag for the entire repository, not for a particular sub-tree. 