### PR TITLE
Permit missing separating space in unreleased link reference definition

### DIFF
--- a/src/parse-changelog.test.ts
+++ b/src/parse-changelog.test.ts
@@ -25,6 +25,27 @@ describe('parseChangelog', () => {
     expect(changelog.getUnreleasedChanges()).toStrictEqual({});
   });
 
+  it('should parse changelog with poorly formatted link reference', () => {
+    const changelog = parseChangelog({
+      changelogContent: outdent`
+        # Changelog
+        All notable changes to this project will be documented in this file.
+
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+        ## [Unreleased]
+
+        [Unreleased]:https://github.com/ExampleUsernameOrOrganization/ExampleRepository/
+        `,
+      repoUrl:
+        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+    });
+
+    expect(changelog.getReleases()).toStrictEqual([]);
+    expect(changelog.getUnreleasedChanges()).toStrictEqual({});
+  });
+
   it('should parse changelog missing title', () => {
     const changelog = parseChangelog({
       changelogContent: outdent`

--- a/src/parse-changelog.ts
+++ b/src/parse-changelog.ts
@@ -32,7 +32,7 @@ export function parseChangelog({
     throw new Error(`Failed to find ${unreleased} header`);
   }
   const unreleasedLinkReferenceDefinition = changelogLines.findIndex((line) => {
-    return line.startsWith(`[${unreleased}]: `);
+    return line.startsWith(`[${unreleased}]:`);
   });
   if (unreleasedLinkReferenceDefinition === -1) {
     throw new Error(`Failed to find ${unreleased} link reference definition`);


### PR DESCRIPTION
This enables the parsing of changelogs without a separating space in their `Unreleased` link reference definition. Changelog updating and validation remain unaffected by this change.

This package is very strict about formatting, however, we can afford to be somewhat lenient during parsing, and I think it's worthwhile to spare users from manually adding spaces to their link reference definitions.