### PR TITLE
Skip validation of "Uncategorized" header for older releases

### DIFF
--- a/src/validate-changelog.test.ts
+++ b/src/validate-changelog.test.ts
@@ -618,7 +618,7 @@ describe('validateChangelog', () => {
       ).toThrow('Uncategorized changes present in the changelog');
     });
 
-    it('should throw if there are uncategorized changes in an older release', () => {
+    it('should not throw if there are uncategorized changes in an older release', () => {
       const changelogWithUnreleasedChanges = changelogWithReleases.replace(
         '## [0.0.2] - 2020-01-01',
         '## [0.0.2] - 2020-01-01\n### Uncategorized\n- More changes\n',
@@ -631,7 +631,7 @@ describe('validateChangelog', () => {
             'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
           isReleaseCandidate: true,
         }),
-      ).toThrow('Uncategorized changes present in the changelog');
+      ).not.toThrow();
     });
   });
 });

--- a/src/validate-changelog.ts
+++ b/src/validate-changelog.ts
@@ -100,6 +100,9 @@ export function validateChangelog({
   const changelog = parseChangelog({ changelogContent, repoUrl });
   const hasUnreleasedChanges =
     Object.keys(changelog.getUnreleasedChanges()).length !== 0;
+  const releaseChanges = currentVersion
+    ? changelog.getReleaseChanges(currentVersion)
+    : undefined;
 
   if (isReleaseCandidate) {
     if (!currentVersion) {
@@ -115,17 +118,8 @@ export function validateChangelog({
     } else if (hasUnreleasedChanges) {
       throw new UnreleasedChangesError();
     } else if (
-      changelog
-        .getReleases()
-        .map((releaseMetadata) => releaseMetadata.version)
-        .map((version) => changelog.getReleaseChanges(version))
-        .filter((releaseChanges) => releaseChanges !== undefined)
-        .map((releasechanges) => releasechanges[ChangeCategory.Uncategorized])
-        .some(
-          (uncategorizedChanges) =>
-            uncategorizedChanges !== undefined &&
-            uncategorizedChanges.length > 0,
-        )
+      releaseChanges?.[ChangeCategory.Uncategorized]?.length &&
+      releaseChanges?.[ChangeCategory.Uncategorized]?.length !== 0
     ) {
       throw new UncategorizedChangesError();
     }


### PR DESCRIPTION
Currently the `validate` command will ensure that no release has uncategorized changes when the `--rc` flag is present, but it doesn't care about uncategorized changes when the `--rc` flag isn't present.

This is against the spirit of the `--rc` flag. That flag should enable extra validation specific to the preparation of the current release. It shouldn't impose further burdens on maintainers that have nothing to do with the current release. This validation is also very inconvenient for some projects (e.g. `metamask-extension`), where the current maintainers may not have all of the context to make improvements to ancient changelog entries.