### PR TITLE
Read repository from package.json if `npm_package_repository_url` is not set

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ import {
   InvalidChangelogError,
   validateChangelog,
 } from './validate-changelog';
+import { getRepositoryUrl } from './repo';
 
 const updateEpilog = `New commits will be added to the "${unreleased}" section (or \
 to the section for the current release if the '--rc' flag is used) in reverse \
@@ -38,12 +39,6 @@ formatting is correct. Verification of the contents is left for manual review.`;
 
 // eslint-disable-next-line node/no-process-env
 const npmPackageVersion = process.env.npm_package_version;
-// eslint-disable-next-line node/no-process-env
-const npmPackageRepositoryUrl = process.env.npm_package_repository_url;
-
-const githubRepositoryUrl = npmPackageRepositoryUrl
-  ? npmPackageRepositoryUrl.replace(/\.git$/u, '')
-  : null;
 
 function isValidUrl(proposedUrl: string) {
   try {
@@ -165,7 +160,7 @@ function configureCommonCommandOptions(_yargs: Argv) {
       type: 'string',
     })
     .option('repo', {
-      default: githubRepositoryUrl,
+      default: getRepositoryUrl(),
       description: `The GitHub repository URL`,
       type: 'string',
     })

--- a/src/repo.test.ts
+++ b/src/repo.test.ts
@@ -1,0 +1,33 @@
+/* eslint-disable node/no-process-env */
+
+import path from 'path';
+import { getRepositoryUrl } from './repo';
+
+describe('getRepositoryUrl', () => {
+  it('reads the repository URL from an environment variable', () => {
+    process.env.npm_package_repository_url =
+      'https://github.com/metamask/auto-changelog';
+
+    expect(getRepositoryUrl()).toBe(
+      'https://github.com/metamask/auto-changelog',
+    );
+  });
+
+  it('reads the repository URL from an environment variable (.git suffix)', () => {
+    process.env.npm_package_repository_url =
+      'https://github.com/metamask/auto-changelog.git';
+
+    expect(getRepositoryUrl()).toBe(
+      'https://github.com/metamask/auto-changelog',
+    );
+  });
+
+  it('reads the repository URL from the package.json', () => {
+    process.env.npm_package_repository_url = '';
+    process.env.PROJECT_CWD = path.resolve(__dirname, '..');
+
+    expect(getRepositoryUrl()).toBe(
+      'https://github.com/MetaMask/auto-changelog',
+    );
+  });
+});

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,0 +1,42 @@
+/* eslint-disable node/no-process-env, node/no-sync */
+
+import path from 'path';
+import fs from 'fs';
+
+interface PackageJson {
+  repository:
+    | string
+    | {
+        url: string;
+      };
+}
+
+export function getRepositoryUrl(): string | null {
+  // Set automatically by NPM or Yarn 1.x
+  const npmPackageRepositoryUrl = process.env.npm_package_repository_url;
+  if (npmPackageRepositoryUrl) {
+    return npmPackageRepositoryUrl.replace(/\.git$/u, '');
+  }
+
+  // Set automatically by Yarn 3.x
+  const projectCwd = process.env.PROJECT_CWD;
+
+  console.log(projectCwd);
+
+  if (projectCwd) {
+    const packageJson = path.resolve(projectCwd, 'package.json');
+    const packageJsonContent = JSON.parse(
+      fs.readFileSync(packageJson, 'utf8'),
+    ) as PackageJson;
+
+    if (typeof packageJsonContent.repository === 'string') {
+      return packageJsonContent.repository.replace(/\.git$/u, '');
+    }
+
+    if (typeof packageJsonContent.repository?.url === 'string') {
+      return packageJsonContent.repository.url.replace(/\.git$/u, '');
+    }
+  }
+
+  return null;
+}

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -20,9 +20,6 @@ export function getRepositoryUrl(): string | null {
 
   // Set automatically by Yarn 3.x
   const projectCwd = process.env.PROJECT_CWD;
-
-  console.log(projectCwd);
-
   if (projectCwd) {
     const packageJson = path.resolve(projectCwd, 'package.json');
     const packageJsonContent = JSON.parse(


### PR DESCRIPTION
In Yarn 3, `npm_package_repository_url` isn't set, and `auto-changelog` fails to parse the repository. In this PR I added a function which first looks at the `npm_package_repository_url`, and if that doesn't exist, looks at `PROJECT_CWD` instead. From there the `package.json` can be parsed in order to get the `repository` automatically.

For details on Yarn 3 environment variables, see [here](https://yarnpkg.com/advanced/lifecycle-scripts#environment-variables).