### PR TITLE
Account for tiny time differences between commits

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -5,7 +5,7 @@ import { ChangeCategory, Version } from './constants';
 import type Changelog from './changelog';
 
 async function getMostRecentTag() {
-  const revListArgs = ['rev-list', '--tags', '--max-count=1'];
+  const revListArgs = ['rev-list', '--tags', '--max-count=1', '--date-order'];
   const results = await runCommand('git', revListArgs);
   if (results.length === 0) {
     return null;


### PR DESCRIPTION
When two tags are created in a repo that differ by mere milliseconds or
smaller, such as would happen in an automated high-level test of the
`create-release-pr` action, `git rev-list --tags` seems to get confused,
and so `getMostRecentTag` may not always return the latest tag. Adding
`--date-order` seems to fix this.