### PR TITLE
Update GitHub actions to match module template

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -6,12 +6,15 @@ on:
   pull_request:
 
 jobs:
-  build-lint-test:
-    name: Build, Lint, and Test
-    runs-on: ubuntu-20.04
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      YARN_CACHE_DIR: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
+      YARN_VERSION: ${{ steps.yarn-version.outputs.YARN_VERSION }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -24,39 +27,123 @@ jobs:
       - name: Get Yarn version
         run: echo "YARN_VERSION=$(yarn --version)" >> "$GITHUB_OUTPUT"
         id: yarn-version
-      - name: Cache yarn dependencies
+      - name: Cache Yarn dependencies
         uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
-          key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn --immutable
-      - run: yarn build
-      - run: yarn lint
-      - run: yarn test
-  validate-changelog:
-    name: Validate changelog
-    runs-on: ubuntu-20.04
+          key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+      - name: Install Yarn dependencies
+        run: yarn --immutable
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x, 19.x]
     steps:
       - uses: actions/checkout@v3
-      - name: Get Node.js version
-        id: nvm
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version: ${{ matrix.node-version }}
+      - name: Restore Yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.prepare.outputs.YARN_CACHE_DIR }}
+          key: yarn-cache-${{ runner.os }}-${{ needs.prepare.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
       - run: yarn --immutable
+      - run: yarn build
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x, 19.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Restore Yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.prepare.outputs.YARN_CACHE_DIR }}
+          key: yarn-cache-${{ runner.os }}-${{ needs.prepare.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+      - run: yarn --immutable
+      - run: yarn lint
       - run: yarn build
       - name: Validate RC changelog
         if: ${{ startsWith(github.head_ref, 'release/') }}
-        run: yarn changelog validate --rc
+        run: yarn auto-changelog validate --rc
       - name: Validate changelog
         if: ${{ !startsWith(github.head_ref, 'release/') }}
-        run: yarn changelog validate
+        run: yarn auto-changelog validate
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x, 19.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Restore Yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ needs.prepare.outputs.YARN_CACHE_DIR }}
+          key: yarn-cache-${{ runner.os }}-${{ needs.prepare.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}-${{ matrix.node-version }}
+      - run: yarn --immutable
+      - run: yarn test
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+  check-workflows:
+    name: Check workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: download-actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/d5f726fb9c9aaff30c8c3787a9b9640f7612838a/scripts/download-actionlint.bash) 1.6.21
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.download-actionlint.outputs.executable }} -color
+        shell: bash
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
-      - build-lint-test
-      - validate-changelog
+      - build
+      - lint
+      - test
+      - check-workflows
     steps:
       - run: echo "Great success!"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -29,12 +29,10 @@ jobs:
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
-      - name: Get Node.js version
-        id: nvm
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
+          node-version-file: '.nvmrc'
       - uses: MetaMask/action-create-release-pr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,29 +1,87 @@
 name: Publish Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches: [main]
 
 jobs:
+  is-release:
+    # release merge commits come from github-actions
+    if: startsWith(github.event.commits[0].author.name, 'github-actions')
+    outputs:
+      IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MetaMask/action-is-release@v1
+        id: is-release
+
   publish-release:
     permissions:
       contents: write
-    if: |
-      github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+    if: needs.is-release.outputs.IS_RELEASE == 'true'
     runs-on: ubuntu-latest
+    needs: is-release
     steps:
       - uses: actions/checkout@v3
         with:
-          # We check out the release pull request's base branch, which will be
-          # used as the base branch for all git operations.
-          ref: ${{ github.event.pull_request.base.ref }}
-      - name: Get Node.js version
-        id: nvm
-        run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v3
+          ref: ${{ github.sha }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
-      - uses: MetaMask/action-publish-release@v1
+          node-version-file: '.nvmrc'
+      - uses: MetaMask/action-publish-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install
+        run: |
+          yarn install
+          yarn build
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./dist
+          key: ${{ github.sha }}
+
+  publish-npm-dry-run:
+    runs-on: ubuntu-latest
+    needs: publish-release
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./dist
+          key: ${{ github.sha }}
+        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
+      - run: npm config set ignore-scripts true
+      - name: Dry Run Publish
+        # omit npm-token token to perform dry run publish
+        uses: MetaMask/action-npm-publish@v1
+        env:
+          SKIP_PREPACK: true
+
+  publish-npm:
+    environment: npm-publish
+    runs-on: ubuntu-latest
+    needs: publish-npm-dry-run
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+      - uses: actions/cache@v3
+        id: restore-build
+        with:
+          path: ./dist
+          key: ${{ github.sha }}
+        # Set `ignore-scripts` to skip `prepublishOnly` because the release was built already in the previous job
+      - run: npm config set ignore-scripts true
+      - name: Publish
+        uses: MetaMask/action-npm-publish@v1
+        with:
+          # This `NPM_TOKEN` needs to be manually set per-repository.
+          # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
+          npm-token: ${{ secrets.NPM_TOKEN }}
+        env:
+          SKIP_PREPACK: true

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
-    "prepack": "yarn build",
+    "prepack": "./scripts/prepack.sh",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",

--- a/scripts/prepack.sh
+++ b/scripts/prepack.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+set -e
+set -o pipefail
+
+if [[ -n $SKIP_PREPACK ]]; then
+  echo "Notice: skipping prepack."
+  exit 0
+fi
+
+yarn build


### PR DESCRIPTION
The GitHub actions have been updated to match the latest used in the module template, with some exceptions. The require-additional-reviewer action was omitted because it's broken for forks, and the documentation-related steps have been omitted because this repository does not yet have API documentation.

See: https://github.com/MetaMask/metamask-module-template/tree/a3b2e531a7961ccc32577ac3c49aa651a14623cd/.github/workflows