### PR TITLE
Apply `[]` syntax for optional params to JSDoc `@param` tags

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -74,8 +74,8 @@ function stringifyCategory(category: ChangeCategory, changes: string[]) {
  * @param version - The release version.
  * @param categories - The categories of changes included in this release.
  * @param options - Additional release options.
- * @param options.date - The date of the release.
- * @param options.status - The status of the release (e.g., "DEPRECATED").
+ * @param [options.date] - The date of the release.
+ * @param [options.status] - The status of the release (e.g., "DEPRECATED").
  * @returns The stringified release section.
  */
 function stringifyRelease(
@@ -269,8 +269,8 @@ export default class Changelog {
    *
    * @param options - Changelog options.
    * @param options.repoUrl - The GitHub repository URL for the current project.
-   * @param options.tagPrefix - The prefix used in tags before the version number.
-   * @param options.formatter - A function that formats the changelog string.
+   * @param [options.tagPrefix] - The prefix used in tags before the version number.
+   * @param [options.formatter] - A function that formats the changelog string.
    */
   constructor({
     repoUrl,
@@ -292,13 +292,13 @@ export default class Changelog {
    * Add a release to the changelog.
    *
    * @param options - Release options.
-   * @param options.addToStart - Determines whether the change is added to the
+   * @param [options.addToStart] - Determines whether the change is added to the
    * top or bottom of the list of changes in this category. This defaults to
    * `true` because changes should be in reverse-chronological order. This
    * should be set to `false` when parsing a changelog top-to-bottom.
-   * @param options.date - An ISO-8601 formatted date, representing the release
+   * @param [options.date] - An ISO-8601 formatted date, representing the release
    * date.
-   * @param options.status - The status of the release (e.g., 'WITHDRAWN',
+   * @param [options.status] - The status of the release (e.g., 'WITHDRAWN',
    * 'DEPRECATED').
    * @param options.version - The version of the current release, which should
    * be a [SemVer](https://semver.org/spec/v2.0.0.html)-compatible version.
@@ -325,13 +325,13 @@ export default class Changelog {
    * Add a change to the changelog.
    *
    * @param options - Change options.
-   * @param options.addToStart - Determines whether the change is added to the
+   * @param [options.addToStart] - Determines whether the change is added to the
    * top or bottom of the list of changes in this category. This defaults to
    * `true` because changes should be in reverse-chronological order. This
    * should be set to `false` when parsing a changelog top-to-bottom.
    * @param options.category - The category of the change.
    * @param options.description - The description of the change.
-   * @param options.version - The version this change was released in. If this
+   * @param [options.version] - The version this change was released in. If this
    * is not given, the change is assumed to be unreleased.
    */
   addChange({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,10 +98,10 @@ type UpdateOptions = {
  *
  * @param options - Update options.
  * @param options.changelogPath - The path to the changelog file.
- * @param options.currentVersion - The current project version.
+ * @param [options.currentVersion] - The current project version.
  * @param options.isReleaseCandidate - Whether the current branch is a release candidate or not.
  * @param options.repoUrl - The GitHub repository URL for the current project.
- * @param options.projectRootDirectory - The root project directory.
+ * @param [options.projectRootDirectory] - The root project directory.
  * @param options.tagPrefix - The prefix used in tags before the version number.
  * @param options.formatter - A custom Markdown formatter to use.
  */
@@ -149,7 +149,7 @@ type ValidateOptions = {
  *
  * @param options - Validation options.
  * @param options.changelogPath - The path to the changelog file.
- * @param options.currentVersion - The current project version.
+ * @param [options.currentVersion] - The current project version.
  * @param options.isReleaseCandidate - Whether the current branch is a release candidate or not.
  * @param options.repoUrl - The GitHub repository URL for the current project.
  * @param options.tagPrefix - The prefix used in tags before the version number.

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,7 +5,7 @@ import Changelog from './changelog';
  *
  * @param options - Changelog options.
  * @param options.repoUrl - The GitHub repository URL for the current project.
- * @param options.tagPrefix - The prefix used in tags before the version number.
+ * @param [options.tagPrefix] - The prefix used in tags before the version number.
  * @returns The initial changelog text.
  */
 export function createEmptyChangelog({

--- a/src/parse-changelog.ts
+++ b/src/parse-changelog.ts
@@ -30,8 +30,8 @@ function isValidChangeCategory(category: string): category is ChangeCategory {
  * @param options - Options.
  * @param options.changelogContent - The changelog to parse.
  * @param options.repoUrl - The GitHub repository URL for the current project.
- * @param options.tagPrefix - The prefix used in tags before the version number.
- * @param options.formatter - A custom Markdown formatter to use.
+ * @param [options.tagPrefix] - The prefix used in tags before the version number.
+ * @param [options.formatter] - A custom Markdown formatter to use.
  * @returns A changelog instance that reflects the changelog text provided.
  */
 export function parseChangelog({
@@ -74,7 +74,7 @@ export function parseChangelog({
    * This is required because change entries can span multiple lines.
    *
    * @param options - Options.
-   * @param options.removeTrailingNewline - Indicates that the trailing newline
+   * @param [options.removeTrailingNewline] - Indicates that the trailing newline
    * is not a part of the change description, and should therefore be removed.
    */
   function finalizePreviousChange({

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -142,7 +142,7 @@ function getAllLoggedPrNumbers(changelog: Changelog) {
  * Get all commit hashes included in the given commit range.
  *
  * @param commitRange - The commit range.
- * @param rootDirectory - The project root directory.
+ * @param [rootDirectory] - The project root directory.
  * @returns A list of commit hashes for the given range.
  */
 async function getCommitHashesInRange(
@@ -172,20 +172,20 @@ export type UpdateChangelogOptions = {
  *
  * @param options - Update options.
  * @param options.changelogContent - The current changelog.
- * @param options.currentVersion - The current version. Required if
+ * @param [options.currentVersion] - The current version. Required if
  * `isReleaseCandidate` is set, but optional otherwise.
  * @param options.repoUrl - The GitHub repository URL for the current project.
  * @param options.isReleaseCandidate - Denotes whether the current project.
  * is in the midst of release preparation or not. If this is set, any new
  * changes are listed under the current release header. Otherwise, they are
  * listed under the 'Unreleased' section.
- * @param options.projectRootDirectory - The root project directory, used to
+ * @param [options.projectRootDirectory] - The root project directory, used to
  * filter results from various git commands. This path is assumed to be either
  * absolute, or relative to the current directory. Defaults to the root of the
  * current git repository.
- * @param options.tagPrefixes - A list of tag prefixes to look for, where the first is the intended
+ * @param [options.tagPrefixes] - A list of tag prefixes to look for, where the first is the intended
  * prefix and each subsequent prefix is a fallback in case the previous tag prefixes are not found.
- * @param options.formatter - A custom Markdown formatter to use.
+ * @param [options.formatter] - A custom Markdown formatter to use.
  * @returns The updated changelog text.
  */
 export async function updateChangelog({

--- a/src/validate-changelog.ts
+++ b/src/validate-changelog.ts
@@ -80,7 +80,7 @@ type ValidateChangelogOptions = {
  *
  * @param options - Validation options.
  * @param options.changelogContent - The current changelog.
- * @param options.currentVersion - The current version. Required if
+ * @param [options.currentVersion] - The current version. Required if
  * `isReleaseCandidate` is set, but optional otherwise.
  * @param options.repoUrl - The GitHub repository URL for the current
  * project.
@@ -88,8 +88,8 @@ type ValidateChangelogOptions = {
  * the midst of release preparation or not. If this is set, this command will
  * also ensure the current version is represented in the changelog with a
  * header, and that there are no unreleased changes present.
- * @param options.tagPrefix - The prefix used in tags before the version number.
- * @param options.formatter - A custom Markdown formatter to use.
+ * @param [options.tagPrefix] - The prefix used in tags before the version number.
+ * @param [options.formatter] - A custom Markdown formatter to use.
  * @throws `InvalidChangelogError` - Will throw if the changelog is invalid
  * @throws `MissingCurrentVersionError` - Will throw if `isReleaseCandidate` is
  * `true` and the changelog is missing the release header for the current


### PR DESCRIPTION
- It can be tricky to tell whether or not a parameter is optional if they are passed in as object properties that might also be nested.
- The JSDoc `[]` syntax gives a simple but clear visual indication of which params are optional.
- This PR annotates all existing params that are defined using the `?:` operator.