### PR TITLE
fix: move @metamask/utils from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "changelog": "node dist/cli.js"
   },
   "dependencies": {
+    "@metamask/utils": "^8.1.0",
     "diff": "^5.0.0",
     "execa": "^5.1.1",
     "prettier": "^2.8.8",
@@ -43,7 +44,6 @@
     "@metamask/eslint-config-jest": "^11.1.0",
     "@metamask/eslint-config-nodejs": "^11.1.0",
     "@metamask/eslint-config-typescript": "^11.1.0",
-    "@metamask/utils": "^8.1.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/diff": "^5.0.0",
     "@types/jest": "^26.0.23",


### PR DESCRIPTION
- Was added as devDependency while importing in runtime in #158.

https://github.com/MetaMask/utils/actions/runs/6601251324/job/17932102826?pr=152

```
node:internal/modules/cjs/loader:1051
  throw err;
  ^

Error: Cannot find module '@metamask/utils'
Require stack:
- /home/runner/work/utils/utils/node_modules/@metamask/auto-changelog/dist/changelog.js
- /home/runner/work/utils/utils/node_modules/@metamask/auto-changelog/dist/init.js
- /home/runner/work/utils/utils/node_modules/@metamask/auto-changelog/dist/cli.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/home/runner/work/utils/utils/node_modules/@metamask/auto-changelog/dist/changelog.js:18:17)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/runner/work/utils/utils/node_modules/@metamask/auto-changelog/dist/changelog.js',
    '/home/runner/work/utils/utils/node_modules/@metamask/auto-changelog/dist/init.js',
    '/home/runner/work/utils/utils/node_modules/@metamask/auto-changelog/dist/cli.js'
  ]
}
```