### PR TITLE
Fix bug introduced to `updateChangelog` in #158

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -310,11 +310,10 @@ export async function updateChangelog({
       description,
     });
   }
-  const newChangelogContent = changelog.toString();
 
-  return changelogContent === newChangelogContent
-    ? undefined
-    : newChangelogContent;
+  const newChangelogContent = changelog.toString();
+  const isChangelogUpdated = changelogContent !== newChangelogContent;
+  return isChangelogUpdated ? newChangelogContent : undefined;
 }
 
 /**

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import execa from 'execa';
 
 import type Changelog from './changelog';
-import { Formatter } from './changelog';
+import { Formatter, getKnownPropertyNames } from './changelog';
 import { ChangeCategory, Version } from './constants';
 import { parseChangelog } from './parse-changelog';
 import { PackageRename } from './shared-types';
@@ -290,7 +290,7 @@ export async function updateChangelog({
     }
 
     const hasUnreleasedChangesToRelease =
-      Object.keys(changelog.getUnreleasedChanges()).length > 0;
+      getKnownPropertyNames(changelog.getUnreleasedChanges()).length > 0;
     if (hasUnreleasedChangesToRelease) {
       changelog.migrateUnreleasedChangesToRelease(currentVersion);
     }

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -20,6 +20,9 @@ async function getMostRecentTag({
 }: {
   tagPrefixes: [string, ...string[]];
 }) {
+  // Ensure we have all tags on remote
+  await runCommand('git', ['fetch', '--tags']);
+
   let mostRecentTagCommitHash: string | null = null;
   for (const tagPrefix of tagPrefixes) {
     const revListArgs = [
@@ -261,8 +264,6 @@ export async function updateChangelog({
     packageRename,
   });
 
-  // Ensure we have all tags on remote
-  await runCommand('git', ['fetch', '--tags']);
   const mostRecentTag = await getMostRecentTag({
     tagPrefixes,
   });

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -195,8 +195,7 @@ async function getNewChangeEntries({
   const commits = await getCommits(commitsHashesSinceLastRelease);
 
   const newCommits = commits.filter(
-    ({ prNumber }) =>
-      prNumber === undefined || !loggedPrNumbers.includes(prNumber),
+    ({ prNumber }) => !prNumber || !loggedPrNumbers.includes(prNumber),
   );
 
   return newCommits.map(({ prNumber, description }) => {


### PR DESCRIPTION
## Motivation

#158 incorrectly refactored the branches in updateChangelog, resulting in a state where new changelog entries weren't added to the return value if isReleaseCandidate is false.

## Explanation

- This error is fixed by moving the logic for retrieving new entries out of the if (isReleaseCandidate) block.
- The code for retrieving new entries is also extracted into its own method: getNewChangeEntries, abstracting away details that obscured the flow of the method's core logic.
- To verify that the buggy logic is correctly restored, it's necessary to compare the current state of updateChangelog to its state before the bug was introduced. For this, see: [diff link](https://github.com/MetaMask/auto-changelog/compare/e8df1ec717f534c8fe84c46ea86a847fa5a32973..da39a58a55571cf4e8a03e28096aa12c02c75f77#diff-4228e8302e41dd1c51e813af8368efdcb40b3d9db3e3f21f417ae87275d9f389R249-R316).

## References

- Closes #180
- Followed by #188