### PR TITLE
Extend tag history retention to changelog update command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,10 @@ type UpdateOptions = {
   projectRootDirectory?: string;
   tagPrefix: string;
   formatter: Formatter;
+  /**
+   * The package rename properties, used in case of package is renamed
+   */
+  packageRename?: PackageRename;
 };
 
 /**
@@ -105,6 +109,8 @@ type UpdateOptions = {
  * @param options.projectRootDirectory - The root project directory.
  * @param options.tagPrefix - The prefix used in tags before the version number.
  * @param options.formatter - A custom Markdown formatter to use.
+ * @param options.packageRename - The package rename properties.
+ * An optional, which is required only in case of package renamed.
  */
 async function update({
   changelogPath,
@@ -114,6 +120,7 @@ async function update({
   projectRootDirectory,
   tagPrefix,
   formatter,
+  packageRename,
 }: UpdateOptions) {
   const changelogContent = await readChangelog(changelogPath);
 
@@ -125,6 +132,7 @@ async function update({
     projectRootDirectory,
     tagPrefixes: [tagPrefix],
     formatter,
+    packageRename,
   });
 
   if (newChangelogContent) {
@@ -465,6 +473,13 @@ async function main() {
   };
 
   if (command === 'update') {
+    let packageRename: PackageRename | undefined;
+    if (versionBeforePackageRename && tagPrefixBeforePackageRename) {
+      packageRename = {
+        versionBeforeRename: versionBeforePackageRename,
+        tagPrefixBeforeRename: tagPrefixBeforePackageRename,
+      };
+    }
     await update({
       changelogPath,
       currentVersion,
@@ -473,6 +488,7 @@ async function main() {
       projectRootDirectory,
       tagPrefix,
       formatter,
+      packageRename,
     });
   } else if (command === 'validate') {
     let packageRename: PackageRename | undefined;

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -5,6 +5,7 @@ import type Changelog from './changelog';
 import { Formatter } from './changelog';
 import { ChangeCategory, Version } from './constants';
 import { parseChangelog } from './parse-changelog';
+import { PackageRename } from './shared-types';
 
 /**
  * Get the most recent tag for a project.
@@ -164,6 +165,10 @@ export type UpdateChangelogOptions = {
   projectRootDirectory?: string;
   tagPrefixes?: [string, ...string[]];
   formatter?: Formatter;
+  /**
+   * The package rename properties, used in case of package is renamed
+   */
+  packageRename?: PackageRename;
 };
 
 /**
@@ -186,6 +191,8 @@ export type UpdateChangelogOptions = {
  * @param options.tagPrefixes - A list of tag prefixes to look for, where the first is the intended
  * prefix and each subsequent prefix is a fallback in case the previous tag prefixes are not found.
  * @param options.formatter - A custom Markdown formatter to use.
+ * @param options.packageRename - The package rename properties.
+ * An optional, which is required only in case of package renamed.
  * @returns The updated changelog text.
  */
 export async function updateChangelog({
@@ -196,12 +203,14 @@ export async function updateChangelog({
   projectRootDirectory,
   tagPrefixes = ['v'],
   formatter = undefined,
+  packageRename,
 }: UpdateChangelogOptions): Promise<string | undefined> {
   const changelog = parseChangelog({
     changelogContent,
     repoUrl,
     tagPrefix: tagPrefixes[0],
     formatter,
+    packageRename,
   });
 
   // Ensure we have all tags on remote


### PR DESCRIPTION
## Explanation
This pull request introduces enhancements that build upon previous modifications made in [PR #157](https://github.com/MetaMask/auto-changelog/pull/157), where we implemented tag history retention for renamed packages. However, those changes were initially applied only to the `changelog` `validate` `command`. With this current PR, we are extending the same functionality to the `changelog` `update` `command` as well.

## References

* Fixes [#183] (https://github.com/MetaMask/auto-changelog/issues/183)