### PR TITLE
BREAKING: Make Prettier the default option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -306,7 +306,7 @@ async function main() {
             type: 'string',
           })
           .option('prettier', {
-            default: false,
+            default: true,
             description: `Expect the changelog to be formatted with Prettier.`,
             type: 'boolean',
           })
@@ -466,7 +466,7 @@ async function main() {
     }
   }
 
-  const formatter = (changelog: string) => {
+  const formatter = async (changelog: string) => {
     return usePrettier
       ? prettier.format(changelog, { parser: 'markdown' })
       : changelog;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -466,7 +466,7 @@ async function main() {
     }
   }
 
-  const formatter = async (changelog: string) => {
+  const formatter = (changelog: string) => {
     return usePrettier
       ? prettier.format(changelog, { parser: 'markdown' })
       : changelog;


### PR DESCRIPTION
Since we're going to release some breaking changes, we may as well make Prettier the default.

It can be disabled by specifying `--no-prettier`.