### PR TITLE
Add way to verify each change has associated PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ or
 
 `npm run auto-changelog validate --tag-prefix-before-package-rename "polling-controller@" --version-before-package-name 0.2.3 --tag-prefix "@metamask/polling-controller@"`
 
+#### Validate that each changelog entry has one or more associated pull requests
+
+`yarn run auto-changelog validate --pr-links`
+
+or
+
+`npm run auto-changelog validate --pr-links`
+
 ## API Usage
 
 Each supported command is a separate named export.
@@ -116,7 +124,7 @@ await fs.writeFile('CHANGELOG.md', updatedChangelog);
 
 ### `validateChangelog`
 
-This command validates the changelog
+This command validates the changelog.
 
 ```javascript
 import { promises as fs } from 'fs';
@@ -132,6 +140,7 @@ try {
     repoUrl:
       'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
     isReleaseCandidate: false,
+    ensureValidPrLinksPresent: true,
   });
   // changelog is valid!
 } catch (error) {

--- a/src/changelog.test.ts
+++ b/src/changelog.test.ts
@@ -1,4 +1,9 @@
+import _outdent from 'outdent';
+
 import Changelog from './changelog';
+import { ChangeCategory } from './constants';
+
+const outdent = _outdent({ trimTrailingNewline: false });
 
 const emptyChangelog = `# Changelog
 All notable changes to this project will be documented in this file.
@@ -27,5 +32,44 @@ describe('Changelog', () => {
     });
 
     expect(await changelog.toString()).toStrictEqual(emptyChangelog);
+  });
+
+  it('should recreate pull request links for change entries based on the repo URL', async () => {
+    const changelog = new Changelog({
+      repoUrl: 'https://github.com/MetaMask/fake-repo',
+    });
+    changelog.addRelease({ version: '1.0.0' });
+    changelog.addChange({
+      version: '1.0.0',
+      category: ChangeCategory.Changed,
+      description: 'This is a cool change\n  - This is a sub-bullet',
+      prNumbers: ['100', '200'],
+    });
+    changelog.addChange({
+      version: '1.0.0',
+      category: ChangeCategory.Changed,
+      description: 'This is a very cool change\nAnd another line',
+      prNumbers: ['300'],
+    });
+
+    expect(await changelog.toString()).toStrictEqual(outdent`
+      # Changelog
+      All notable changes to this project will be documented in this file.
+
+      The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+      and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+      ## [Unreleased]
+
+      ## [1.0.0]
+      ### Changed
+      - This is a very cool change ([#300](https://github.com/MetaMask/fake-repo/pull/300))
+      And another line
+      - This is a cool change ([#100](https://github.com/MetaMask/fake-repo/pull/100), [#200](https://github.com/MetaMask/fake-repo/pull/200))
+        - This is a sub-bullet
+
+      [Unreleased]: https://github.com/MetaMask/fake-repo/compare/v1.0.0...HEAD
+      [1.0.0]: https://github.com/MetaMask/fake-repo/releases/tag/v1.0.0
+    `);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { promises as fs, constants as fsConstants } from 'fs';
 import path from 'path';
 import semver from 'semver';
@@ -158,6 +156,11 @@ type ValidateOptions = {
    * The package rename properties, used in case of package is renamed
    */
   packageRename?: PackageRename;
+  /**
+   * Whether to validate that each changelog entry has one or more links to
+   * associated pull requests within the repository (true) or not (false).
+   */
+  ensureValidPrLinksPresent: boolean;
 };
 
 /**
@@ -172,7 +175,9 @@ type ValidateOptions = {
  * @param options.fix - Whether to attempt to fix the changelog or not.
  * @param options.formatter - A custom Markdown formatter to use.
  * @param options.packageRename - The package rename properties.
- * An optional, which is required only in case of package renamed.
+ * @param options.ensureValidPrLinksPresent - Whether to validate that each
+ * changelog entry has one or more links to associated pull requests within the
+ * repository (true) or not (false).
  */
 async function validate({
   changelogPath,
@@ -183,6 +188,7 @@ async function validate({
   fix,
   formatter,
   packageRename,
+  ensureValidPrLinksPresent,
 }: ValidateOptions) {
   const changelogContent = await readChangelog(changelogPath);
 
@@ -195,6 +201,7 @@ async function validate({
       tagPrefix,
       formatter,
       packageRename,
+      ensureValidPrLinksPresent,
     });
     return undefined;
   } catch (error) {
@@ -351,6 +358,12 @@ async function main() {
             description: `Expect the changelog to be formatted with Prettier.`,
             type: 'boolean',
           })
+          .option('prLinks', {
+            default: false,
+            description:
+              'Verify that each changelog entry has one or more links to associated pull requests within the repository',
+            type: 'boolean',
+          })
           .epilog(validateEpilog),
     )
     .command('init', 'Initialize a new empty changelog', (_yargs) => {
@@ -374,6 +387,7 @@ async function main() {
     versionBeforePackageRename,
     tagPrefixBeforePackageRename,
     autoCategorize,
+    prLinks,
   } = argv;
   let { currentVersion } = argv;
 
@@ -521,6 +535,7 @@ async function main() {
       fix,
       formatter,
       packageRename,
+      ensureValidPrLinksPresent: prLinks,
     });
   } else if (command === 'init') {
     await init({

--- a/src/parse-changelog.test.ts
+++ b/src/parse-changelog.test.ts
@@ -123,15 +123,30 @@ describe('parseChangelog', () => {
     ]);
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else'],
+      Changed: [
+        {
+          description: 'Something else',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getReleaseChanges('0.0.2')).toStrictEqual({
-      Fixed: ['Something'],
+      Fixed: [
+        {
+          description: 'Something',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
-      Changed: ['Something'],
+      Changed: [
+        {
+          description: 'Something',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getRelease('1.0.0')).toStrictEqual({
@@ -187,15 +202,30 @@ describe('parseChangelog', () => {
     ]);
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else'],
+      Changed: [
+        {
+          description: 'Something else',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getReleaseChanges('0.0.2')).toStrictEqual({
-      Fixed: ['Something'],
+      Fixed: [
+        {
+          description: 'Something',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
-      Changed: ['Something'],
+      Changed: [
+        {
+          description: 'Something',
+          prNumbers: [],
+        },
+      ],
     });
     expect(changelog.getUnreleasedChanges()).toStrictEqual({});
   });
@@ -302,7 +332,12 @@ describe('parseChangelog', () => {
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else\nFurther explanation of changes'],
+      Changed: [
+        {
+          description: 'Something else\nFurther explanation of changes',
+          prNumbers: [],
+        },
+      ],
     });
   });
 
@@ -330,7 +365,12 @@ describe('parseChangelog', () => {
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else\n  - Further explanation of changes'],
+      Changed: [
+        {
+          description: 'Something else\n  - Further explanation of changes',
+          prNumbers: [],
+        },
+      ],
     });
   });
 
@@ -359,7 +399,12 @@ describe('parseChangelog', () => {
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else\n  - Further explanation of changes\n'],
+      Changed: [
+        {
+          description: 'Something else\n  - Further explanation of changes\n',
+          prNumbers: [],
+        },
+      ],
     });
   });
 
@@ -390,9 +435,18 @@ describe('parseChangelog', () => {
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else\n  - Further explanation of changes'],
+      Changed: [
+        {
+          description: 'Something else\n  - Further explanation of changes',
+          prNumbers: [],
+        },
+      ],
       Fixed: [
-        'Not including newline between change categories as part of change entry',
+        {
+          description:
+            'Not including newline between change categories as part of change entry',
+          prNumbers: [],
+        },
       ],
     });
   });
@@ -425,7 +479,12 @@ describe('parseChangelog', () => {
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else\n  - Further explanation of changes'],
+      Changed: [
+        {
+          description: 'Something else\n  - Further explanation of changes',
+          prNumbers: [],
+        },
+      ],
     });
   });
 
@@ -453,7 +512,12 @@ describe('parseChangelog', () => {
     ]);
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['Something else'],
+      Changed: [
+        {
+          description: 'Something else',
+          prNumbers: [],
+        },
+      ],
     });
     expect(changelog.getUnreleasedChanges()).toStrictEqual({});
   });
@@ -796,15 +860,30 @@ describe('parseChangelog', () => {
     ]);
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
-      Changed: ['package renamed'],
+      Changed: [
+        {
+          description: 'package renamed',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getReleaseChanges('0.0.2')).toStrictEqual({
-      Fixed: ['Something'],
+      Fixed: [
+        {
+          description: 'Something',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
-      Changed: ['Something'],
+      Changed: [
+        {
+          description: 'Something',
+          prNumbers: [],
+        },
+      ],
     });
 
     expect(changelog.getRelease('1.0.0')).toStrictEqual({
@@ -822,5 +901,428 @@ describe('parseChangelog', () => {
       "Specified release version does not exist: '2.0.0'",
     );
     expect(changelog.getUnreleasedChanges()).toStrictEqual({});
+  });
+
+  describe('when shouldExtractPrLinks is true', () => {
+    it('should parse changelog with pull request links after changelog entries', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something else ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+
+          ## [0.0.2]
+          ### Fixed
+          - Fix something
+
+          ## [0.0.1]
+          ### Added
+          - Initial release ([#456](anything goes here actually))
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+          [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
+          [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something else',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
+        Added: [
+          {
+            description: 'Initial release',
+            prNumbers: ['456'],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog with pull request links at end of first line of multi-line change description', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+          This is a cool change, you will really like it.
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description:
+              'Change something\nThis is a cool change, you will really like it.',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog with pull request links at end of first line of change description with sub-bullets', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+            - This is a cool change, you will really like it.
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description:
+              'Change something\n  - This is a cool change, you will really like it.',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+    });
+
+    it('should preserve links within sub-bullets', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something
+            - This is a cool change, you will really like it. ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description:
+              'Change something\n  - This is a cool change, you will really like it. ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))',
+            prNumbers: [],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog with pull request links somewhere within entry, not just at end', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200)). And something else.
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something. And something else.',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+    });
+
+    it('should combine multiple pull request lists', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200)) ([#300](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/300))
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100', '200', '300'],
+          },
+        ],
+      });
+    });
+
+    it('should de-duplicate pull request links in same list', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100'],
+          },
+        ],
+      });
+    });
+
+    it('should de-duplicate pull request links in separate lists', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100)) ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100'],
+          },
+        ],
+      });
+    });
+
+    it('should preserve non-pull request links or malformed link syntax after changelog entries as part of the entry text itself', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something else ([123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))
+
+          ## [0.0.3]
+          ### Deprecated
+          - Deprecate whatever([#123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))
+
+          ## [0.0.2]
+          ### Fixed
+          - Fix something
+
+          ## [0.0.1]
+          ### Added
+          - Initial release ([#789](https://example.com)
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.3...v1.0.0
+          [0.0.3]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v0.0.3
+          [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
+          [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            // Missing '#'
+            description:
+              'Change something else ([123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))',
+            prNumbers: [],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.3')).toStrictEqual({
+        Deprecated: [
+          {
+            // Missing space before link
+            description:
+              'Deprecate whatever([#123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))',
+            prNumbers: [],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.2')).toStrictEqual({
+        Fixed: [
+          {
+            // Missing link
+            description: 'Fix something',
+            prNumbers: [],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
+        Added: [
+          {
+            // Incorrect URL
+            description: 'Initial release ([#789](https://example.com)',
+            prNumbers: [],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('when shouldExtractPrLinks is false', () => {
+    it('should not parse pull request links after changelog entries specially', () => {
+      const changelog = parseChangelog({
+        changelogContent: outdent`
+          # Changelog
+          All notable changes to this project will be documented in this file.
+
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## [Unreleased]
+
+          ## [1.0.0]
+          ### Changed
+          - Change something else ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+
+          ## [0.0.2]
+          ### Fixed
+          - Fix something
+
+          ## [0.0.1]
+          ### Added
+          - Initial release ([#456](anything goes here actually))
+
+          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+          [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
+          [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
+        `,
+        repoUrl:
+          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        shouldExtractPrLinks: false,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description:
+              'Change something else ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))',
+            prNumbers: [],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
+        Added: [
+          {
+            description:
+              'Initial release ([#456](anything goes here actually))',
+            prNumbers: [],
+          },
+        ],
+      });
+    });
   });
 });

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -50,22 +50,20 @@ async function getMostRecentTag({
 }
 
 /**
- * Get all change descriptions from a changelog.
+ * Get all changes from a changelog.
  *
  * @param changelog - The changelog.
  * @returns All commit descriptions included in the given changelog.
  */
-function getAllChangeDescriptions(changelog: Changelog) {
+function getAllChanges(changelog: Changelog) {
   const releases = changelog.getReleases();
-  const changeDescriptions = Object.values(
-    changelog.getUnreleasedChanges(),
-  ).flat();
+  const changes = Object.values(changelog.getUnreleasedChanges()).flat();
   for (const release of releases) {
-    changeDescriptions.push(
+    changes.push(
       ...Object.values(changelog.getReleaseChanges(release.version)).flat(),
     );
   }
-  return changeDescriptions;
+  return changes;
 }
 
 /**
@@ -75,19 +73,7 @@ function getAllChangeDescriptions(changelog: Changelog) {
  * @returns All pull request numbers included in the given changelog.
  */
 function getAllLoggedPrNumbers(changelog: Changelog) {
-  const changeDescriptions = getAllChangeDescriptions(changelog);
-
-  const prNumbersWithChangelogEntries = [];
-  for (const description of changeDescriptions) {
-    if (!description) {
-      continue;
-    }
-    const matchResults = description.matchAll(/\[#(\d+)\]/gu);
-    const prNumbers = Array.from(matchResults, (result) => result[1]);
-    prNumbersWithChangelogEntries.push(...prNumbers);
-  }
-
-  return prNumbersWithChangelogEntries;
+  return getAllChanges(changelog).flatMap((change) => change.prNumbers);
 }
 
 export type UpdateChangelogOptions = {


### PR DESCRIPTION
This commit adds a new option to the `validate` command, `--pr-links`, which will cause an error to be thrown if:

- a changelog entry does not have one or more links to pull requests after it
- a changelog entry does have PR links present, but they do not point to the project's repo
- a changelog entry does have PR links present, but they are not positioned at the very end of the line

The `ensureValidPrLinksPresent` option has also been added to `validateChangelog`.

If this option is provided, then `parseChangelog` is instructed to look for and extract pull request numbers from changelog entries. The list of numbers will then be checked for in the validation step. It is also used to reconstruct pull request links when the changelog is stringified.

Note that because this commit changes what `parseChangelog` returns, this is a breaking change.

Closes #150.

## Changelog

### Added

- Add a way to ensure that each changelog entry has a well-formatted list of PR links at the end of the line (or throws if this is not the case).
  - Add `--pr-links` / `--prLinks` to the `validate` command
  - Add `ensureValidPrLinksPresent` to `validateChangelog`
- Add `shouldExtractPrLinks` to `parseChangelog` which, if true, will attempt to look for and extract PR links/numbers from each changelog entry.
- Add optional option `prNumbers` to `Changelog.addChange`, which will be combined with the description when the changelog is stringified.

### Changed

- **BREAKING:** `Changelog.getReleaseChanges` and `Changelog.getUnreleasedChanges` now return an array of objects (`{ description, prNumbers }`) rather than array of strings.

## Manual testing

- Run `yarn build`
- Run `yarn run changelog validate --pr-links`. This will validate this package's changelog, checking for PR links.
- See that validation currently fails because one of the entries in 1.0.0 is invalid. Correct this by placing the period _before_ the PR link.
- Run `yarn run changelog validate --pr-links` again.
- See that validation fails again because of the entries in 2.3.0 has duplicated links. Remove the duplicate links.
- Run `yarn run changelog validate --pr-links` again.
- See no output.