### PR TITLE
Sync supported Node versions w/ module template

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -14,7 +14,7 @@ jobs:
       YARN_VERSION: ${{ steps.yarn-version.outputs.YARN_VERSION }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -41,7 +41,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -69,7 +69,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -104,7 +104,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "packageManager": "yarn@3.2.4",
   "engines": {
-    "node": "^18.18 || >=20"
+    "node": "^18.20 || ^20.17 || >=22"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
- Bump support for Node 18.x to at least 18.20
- Limit support for Node 20.x to at least 20.17
- Add support for Node 22 and higher