### PR TITLE
Fix path to `bin` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
-  "bin": "dist/cli.js",
+  "bin": "dist/cli.mjs",
   "files": [
     "dist"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,7 +871,7 @@ __metadata:
   peerDependencies:
     prettier: ">=3.0.0"
   bin:
-    auto-changelog: dist/cli.js
+    auto-changelog: dist/cli.mjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`bin` was pointing to `dist/cli.js` which no longer exists after #226, causing the CLI to break:

```
$ yarn changelog:validate
node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module './node_modules/@metamask/auto-changelog/dist/cli.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:173:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```