### PR TITLE
feat: parse `CHANGELOG entry:` and `no-changelog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Look for `CHANGELOG entry:` in the PR description, and look for `no-changelog` label, then apply this to the generated CHANGELOG, plus properly categorize by Conventional Commit type, including our custom ConventionalCommitType.RELEASE (#247)
+
 ## [5.0.2]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/cross-spawn": "^6.0.2",
     "@types/diff": "^5.0.0",
     "@types/jest": "^26.0.23",
+    "@types/node": "^22.18.0",
     "@types/semver": "^7.3.6",
     "@types/yargs": "^16.0.1",
     "@typescript-eslint/eslint-plugin": "^5.42.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@octokit/rest": "^22.0.0",
+    "@octokit/rest": "^20.0.0",
     "diff": "^5.0.0",
     "execa": "^5.1.1",
     "semver": "^7.3.5",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@octokit/rest": "^22.0.0",
     "diff": "^5.0.0",
     "execa": "^5.1.1",
     "semver": "^7.3.5",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -95,7 +95,7 @@ type UpdateOptions = {
    */
   packageRename?: PackageRename;
   /**
-   * Whether to use `CHANGELOG entry:` from the commit body
+   * Whether to use `CHANGELOG entry:` from the commit body and the no-changelog label
    */
   useChangelogEntry: boolean;
   /**
@@ -117,7 +117,7 @@ type UpdateOptions = {
  * @param options.formatter - A custom Markdown formatter to use.
  * @param options.packageRename - The package rename properties.
  * @param options.autoCategorize - Whether to categorize commits automatically based on their messages.
- * @param options.useChangelogEntry - Whether to read `CHANGELOG entry:` from the commit body.
+ * @param options.useChangelogEntry - Whether to read `CHANGELOG entry:` from the commit body and the no-changelog label.
  * @param options.useShortPrLink - Whether to use short PR links in the changelog entries.
  */
 async function update({
@@ -346,7 +346,8 @@ async function main() {
           })
           .option('useChangelogEntry', {
             default: false,
-            description: 'Read `CHANGELOG entry:` from the commit body',
+            description:
+              'Read `CHANGELOG entry:` from the commit body and the no-changelog label',
             type: 'boolean',
           })
           .option('useShortPrLink', {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,7 +115,9 @@ type UpdateOptions = {
  * @param options.projectRootDirectory - The root project directory.
  * @param options.tagPrefix - The prefix used in tags before the version number.
  * @param options.formatter - A custom Markdown formatter to use.
- * @param options.packageRename - The package rename properties.
+ * @param options.packageRename - The package rename properties. Optional.
+ * Only needed when retrieving a changelog for a renamed package
+ * (e.g., utils -> @metamask/utils).
  * @param options.autoCategorize - Whether to categorize commits automatically based on their messages.
  * @param options.useChangelogEntry - Whether to read `CHANGELOG entry:` from the commit body and the no-changelog label.
  * @param options.useShortPrLink - Whether to use short PR links in the changelog entries.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,6 +94,14 @@ type UpdateOptions = {
    * The package rename properties, used in case of package is renamed
    */
   packageRename?: PackageRename;
+  /**
+   * Whether to use `CHANGELOG entry:` from the commit body
+   */
+  useChangelogEntry: boolean;
+  /**
+   * Whether to use short PR links in the changelog entries
+   */
+  useShortPrLink: boolean;
 };
 
 /**
@@ -109,7 +117,8 @@ type UpdateOptions = {
  * @param options.formatter - A custom Markdown formatter to use.
  * @param options.packageRename - The package rename properties.
  * @param options.autoCategorize - Whether to categorize commits automatically based on their messages.
- * An optional, which is required only in case of package renamed.
+ * @param options.useChangelogEntry - Whether to read `CHANGELOG entry:` from the commit body.
+ * @param options.useShortPrLink - Whether to use short PR links in the changelog entries.
  */
 async function update({
   changelogPath,
@@ -121,6 +130,8 @@ async function update({
   formatter,
   packageRename,
   autoCategorize,
+  useChangelogEntry,
+  useShortPrLink,
 }: UpdateOptions) {
   const changelogContent = await readChangelog(changelogPath);
 
@@ -134,6 +145,8 @@ async function update({
     formatter,
     packageRename,
     autoCategorize,
+    useChangelogEntry,
+    useShortPrLink,
   });
 
   if (newChangelogContent) {
@@ -331,6 +344,16 @@ async function main() {
             description: `Expect the changelog to be formatted with Prettier.`,
             type: 'boolean',
           })
+          .option('useChangelogEntry', {
+            default: false,
+            description: 'Read `CHANGELOG entry:` from the commit body',
+            type: 'boolean',
+          })
+          .option('useShortPrLink', {
+            default: false,
+            description: 'Use short PR links in the changelog entries',
+            type: 'boolean',
+          })
           .epilog(updateEpilog),
     )
     .command(
@@ -388,6 +411,8 @@ async function main() {
     tagPrefixBeforePackageRename,
     autoCategorize,
     prLinks,
+    useChangelogEntry,
+    useShortPrLink,
   } = argv;
   let { currentVersion } = argv;
 
@@ -517,6 +542,8 @@ async function main() {
       formatter,
       packageRename,
       autoCategorize,
+      useChangelogEntry: Boolean(useChangelogEntry),
+      useShortPrLink: Boolean(useShortPrLink),
     });
   } else if (command === 'validate') {
     let packageRename: PackageRename | undefined;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,15 +7,23 @@ export type Version = string;
  * A [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) type.
  */
 export enum ConventionalCommitType {
-  /**
-   * fix: a commit of the type fix patches a bug in your codebase
-   */
-  Fix = 'fix',
-  /**
-   * a commit of the type feat introduces a new feature to the codebase
-   */
-  Feat = 'feat',
+  FEAT = 'feat', // A new feature
+  FIX = 'fix', // A bug fix
+  DOCS = 'docs', // Documentation only changes
+  STYLE = 'style', // Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+  REFACTOR = 'refactor', // A code change that neither fixes a bug nor adds a feature
+  PERF = 'perf', // A code change that improves performance
+  TEST = 'test', // Adding missing tests or correcting existing tests
+  BUILD = 'build', // Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+  CI = 'ci', // Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+  CHORE = 'chore', // Other changes that don't modify src or test files (use this sparingly)
+  REVERT = 'revert', // Reverts a previous commit
+
+  // Custom types for MetaMask
+  BUMP = 'bump', // A version bump to dependencies
+  RELEASE = 'release', // A release commit, made on a release branch or to0 support the release process
 }
+
 /**
  * Change categories.
  *
@@ -58,6 +66,11 @@ export enum ChangeCategory {
    * For any changes that have yet to be categorized.
    */
   Uncategorized = 'Uncategorized',
+
+  /**
+   * For changes that should be excluded from the changelog.
+   */
+  Excluded = 'Excluded',
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -93,7 +93,7 @@ export const orderedChangeCategories: ChangeCategory[] = [
 export const unreleased = 'Unreleased';
 
 /**
- * Keywords that indicate a commit should be excluded from the changelog.
+ * Lowercase keywords that indicate a commit should be excluded from the changelog.
  */
 export const keywordsToIndicateExcluded: string[] = [
   'Bump main version to',
@@ -105,4 +105,4 @@ export const keywordsToIndicateExcluded: string[] = [
   'INFRA-',
   'merge',
   'New Crowdin translations',
-];
+].map((word) => word.toLowerCase());

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -91,3 +91,18 @@ export const orderedChangeCategories: ChangeCategory[] = [
  * The header for the section of the changelog listing unreleased changes.
  */
 export const unreleased = 'Unreleased';
+
+/**
+ * Keywords that indicate a commit should be excluded from the changelog.
+ */
+export const keywordsToIndicateExcluded: string[] = [
+  'Bump main version to',
+  'changelog',
+  'cherry-pick',
+  'cp-',
+  'e2e',
+  'flaky test',
+  'INFRA-',
+  'merge',
+  'New Crowdin translations',
+];

--- a/src/get-new-changes.ts
+++ b/src/get-new-changes.ts
@@ -1,11 +1,14 @@
 import { strict as assert } from 'assert';
-import execa from 'execa';
+
+import { runCommand, runCommandAndSplit } from './run-command';
 
 export type AddNewCommitsOptions = {
   mostRecentTag: string | null;
   repoUrl: string;
   loggedPrNumbers: string[];
   projectRootDirectory?: string;
+  useChangelogEntry: boolean;
+  useShortPrLink: boolean;
 };
 
 /**
@@ -23,45 +26,71 @@ async function getCommitHashesInRange(
   if (rootDirectory) {
     revListArgs.push(rootDirectory);
   }
-  return await runCommand('git', revListArgs);
+  return await runCommandAndSplit('git', revListArgs);
 }
 
 /**
  * Get commit details for each given commit hash.
  *
  * @param commitHashes - The list of commit hashes.
+ * @param useChangelogEntry - Whether to use `CHANGELOG entry:` from the commit body.
  * @returns Commit details for each commit, including description and PR number (if present).
  */
-async function getCommits(commitHashes: string[]) {
-  const commits: { prNumber?: string; description: string }[] = [];
+async function getCommits(commitHashes: string[], useChangelogEntry: boolean) {
+  const commits: { prNumber?: string; subject: string; description: string }[] =
+    [];
   for (const commitHash of commitHashes) {
-    const [subject] = await runCommand('git', [
+    const subject = await runCommand('git', [
       'show',
       '-s',
       '--format=%s',
       commitHash,
     ]);
+
     assert.ok(
       Boolean(subject),
       `"git show" returned empty subject for commit "${commitHash}".`,
     );
 
-    let matchResults = subject.match(/\(#(\d+)\)/u);
+    // console.log({ commitHash, subject, body });
+
+    const subjectMatch = subject.match(/\(#(\d+)\)/u);
+
     let prNumber: string | undefined;
     let description = subject;
 
-    if (matchResults) {
+    if (subjectMatch) {
       // Squash & Merge: the commit subject is parsed as `<description> (#<PR ID>)`
-      prNumber = matchResults[1];
-      description = subject.match(/^(.+)\s\(#\d+\)/u)?.[1] ?? '';
+      prNumber = subjectMatch[1];
+
+      if (useChangelogEntry) {
+        const body = await runCommand('git', [
+          'show',
+          '-s',
+          '--format=%b',
+          commitHash,
+        ]);
+
+        const changelogMatch = body.match(/\nCHANGELOG entry:\s(\S.+?)\n\n/su);
+
+        if (changelogMatch) {
+          const changelogEntry = changelogMatch[1].replace('\n', ' ');
+
+          description = changelogEntry; // This may be string 'null' to indicate no description
+        } else {
+          description = subject.match(/^(.+)\s\(#\d+\)/u)?.[1] ?? '';
+        }
+      } else {
+        description = subject.match(/^(.+)\s\(#\d+\)/u)?.[1] ?? '';
+      }
     } else {
       // Merge: the PR ID is parsed from the git subject (which is of the form `Merge pull request
       // #<PR ID> from <branch>`, and the description is assumed to be the first line of the body.
       // If no body is found, the description is set to the commit subject
-      matchResults = subject.match(/#(\d+)\sfrom/u);
-      if (matchResults) {
-        prNumber = matchResults[1];
-        const [firstLineOfBody] = await runCommand('git', [
+      const mergeMatch = subject.match(/#(\d+)\sfrom/u);
+      if (mergeMatch) {
+        prNumber = mergeMatch[1];
+        const [firstLineOfBody] = await runCommandAndSplit('git', [
           'show',
           '-s',
           '--format=%b',
@@ -73,8 +102,12 @@ async function getCommits(commitHashes: string[]) {
     // Otherwise:
     // Normal commits: The commit subject is the description, and the PR ID is omitted.
 
-    commits.push({ prNumber, description });
+    if (description !== 'null') {
+      // String 'null' is used to indicate no description
+      commits.push({ prNumber, subject, description });
+    }
   }
+
   return commits;
 }
 
@@ -89,6 +122,8 @@ async function getCommits(commitHashes: string[]) {
  * filter results from various git commands. This path is assumed to be either
  * absolute, or relative to the current directory. Defaults to the root of the
  * current git repository.
+ * @param options.useChangelogEntry - Whether to use `CHANGELOG entry:` from the commit body.
+ * @param options.useShortPrLink - Whether to use short PR links in the changelog entries.
  * @returns A list of new change entries to add to the changelog, based on commits made since the last release.
  */
 export async function getNewChangeEntries({
@@ -96,6 +131,8 @@ export async function getNewChangeEntries({
   repoUrl,
   loggedPrNumbers,
   projectRootDirectory,
+  useChangelogEntry,
+  useShortPrLink,
 }: AddNewCommitsOptions) {
   const commitRange =
     mostRecentTag === null ? 'HEAD' : `${mostRecentTag}..HEAD`;
@@ -103,32 +140,26 @@ export async function getNewChangeEntries({
     commitRange,
     projectRootDirectory,
   );
-  const commits = await getCommits(commitsHashesSinceLastRelease);
+  const commits = await getCommits(
+    commitsHashesSinceLastRelease,
+    useChangelogEntry,
+  );
 
   const newCommits = commits.filter(
     ({ prNumber }) => !prNumber || !loggedPrNumbers.includes(prNumber),
   );
 
-  return newCommits.map(({ prNumber, description }) => {
-    if (prNumber) {
-      const suffix = `([#${prNumber}](${repoUrl}/pull/${prNumber}))`;
-      return `${description} ${suffix}`;
-    }
-    return description;
-  });
-}
+  return newCommits.map(({ prNumber, subject, description }) => {
+    let newDescription = description;
 
-/**
- * Executes a shell command in a child process and returns what it wrote to
- * stdout, or rejects if the process exited with an error.
- *
- * @param command - The command to run, e.g. "git".
- * @param args - The arguments to the command.
- * @returns An array of the non-empty lines returned by the command.
- */
-async function runCommand(command: string, args: string[]): Promise<string[]> {
-  return (await execa(command, [...args])).stdout
-    .trim()
-    .split('\n')
-    .filter((line) => line !== '');
+    if (prNumber) {
+      const suffix = useShortPrLink
+        ? `(#${prNumber})`
+        : `([#${prNumber}](${repoUrl}/pull/${prNumber}))`;
+
+      newDescription = `${description} ${suffix}`;
+    }
+
+    return { description: newDescription, subject };
+  });
 }

--- a/src/get-new-changes.ts
+++ b/src/get-new-changes.ts
@@ -213,14 +213,20 @@ export async function getNewChangeEntries({
   );
 
   return newCommits.map(({ prNumber, subject, description }) => {
-    let newDescription = description;
+    // Handle the edge case where the PR description includes multiple changelog entries with this format:
+    //   CHANGELOG entry: Added support to Solana tokens with multiplier (#509)
+    //   CHANGELOG entry: Fix a bug that was causing to show spam Solana transactions in the activity list (#515)
+    //   CHANGELOG entry: Fixed an issue that was causing to show an empty symbol instead of UNKNOWN in activity list for Solana tokens with no metadata (#517)
+    // This is not a supposed to happen, but we've seen engineers doing it already.
+    // Example PR on metamask-extension repo: (#35695)
+    let newDescription = description?.replace(/CHANGELOG entry: /gu, '');
 
     if (prNumber) {
       const suffix = useShortPrLink
         ? `(#${prNumber})`
         : `([#${prNumber}](${repoUrl}/pull/${prNumber}))`;
 
-      newDescription = `${description} ${suffix}`;
+      newDescription = `${newDescription} ${suffix}`;
     }
 
     return { description: newDescription, subject };

--- a/src/get-new-changes.ts
+++ b/src/get-new-changes.ts
@@ -76,7 +76,10 @@ async function getCommits(
   repoUrl: string,
   useChangelogEntry: boolean,
 ) {
-  initOctoKit();
+  // Only initialize Octokit if we need to fetch PR labels
+  if (useChangelogEntry) {
+    initOctoKit();
+  }
 
   const commits: { prNumber?: string; subject: string; description: string }[] =
     [];

--- a/src/get-new-changes.ts
+++ b/src/get-new-changes.ts
@@ -226,7 +226,13 @@ export async function getNewChangeEntries({
         ? `(#${prNumber})`
         : `([#${prNumber}](${repoUrl}/pull/${prNumber}))`;
 
-      newDescription = `${newDescription} ${suffix}`;
+      if (newDescription) {
+        const lines = newDescription.split('\n');
+        lines[0] = `${lines[0]} ${suffix}`; // Append suffix to the first line (next lines are considered part of the description and ignored by the parsing logic)
+        newDescription = lines.join('\n');
+      } else {
+        newDescription = suffix;
+      }
     }
 
     return { description: newDescription, subject };

--- a/src/get-new-changes.ts
+++ b/src/get-new-changes.ts
@@ -88,6 +88,12 @@ async function getCommits(
           const changelogEntry = changelogMatch[1].replace('\n', ' ');
 
           description = changelogEntry; // This may be string 'null' to indicate no description
+
+          if (description !== 'null') {
+            // Make description coming from `CHANGELOG entry:` start with an uppercase letter
+            description =
+              description.charAt(0).toUpperCase() + description.slice(1);
+          }
         } else {
           description = subject.match(/^(.+)\s\(#\d+\)/u)?.[1] ?? '';
         }
@@ -100,6 +106,10 @@ async function getCommits(
 
           if (prLabels.includes('no-changelog')) {
             description = 'null'; // Has the no-changelog label, use string 'null' to indicate no description
+          } else {
+            // Make description start with an uppercase letter
+            description =
+              description.charAt(0).toUpperCase() + description.slice(1);
           }
         }
       } else {
@@ -124,8 +134,8 @@ async function getCommits(
     // Otherwise:
     // Normal commits: The commit subject is the description, and the PR ID is omitted.
 
+    // String 'null' is used to indicate no description
     if (description !== 'null') {
-      // String 'null' is used to indicate no description
       commits.push({ prNumber, subject, description });
     }
   }

--- a/src/get-new-changes.ts
+++ b/src/get-new-changes.ts
@@ -106,10 +106,6 @@ async function getCommits(
 
           if (prLabels.includes('no-changelog')) {
             description = 'null'; // Has the no-changelog label, use string 'null' to indicate no description
-          } else {
-            // Make description start with an uppercase letter
-            description =
-              description.charAt(0).toUpperCase() + description.slice(1);
           }
         }
       } else {

--- a/src/parse-changelog.test.ts
+++ b/src/parse-changelog.test.ts
@@ -4,6 +4,49 @@ import { parseChangelog } from './parse-changelog';
 
 const outdent = _outdent({ trimTrailingNewline: false });
 
+const repoUrl =
+  'https://github.com/ExampleUsernameOrOrganization/ExampleRepository';
+
+const COMMON_HEADER = outdent`# Changelog
+  All notable changes to this project will be documented in this file.
+
+  The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+  and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+  ## [Unreleased]
+`;
+
+const COMMON_REFERENCE_LINKS_1 = outdent`[Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+  [1.0.0]: ${repoUrl}/compare/v0.0.2...v1.0.0
+`;
+const COMMON_REFERENCE_LINKS_3 = outdent`[Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+  [1.0.0]: ${repoUrl}/compare/v0.0.2...v1.0.0
+  [0.0.2]: ${repoUrl}/compare/v0.0.1...v0.0.2
+  [0.0.1]: ${repoUrl}/releases/tag/v0.0.1
+`;
+const COMMON_REFERENCE_LINKS_4 = outdent`[Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+  [1.0.0]: ${repoUrl}/compare/v0.0.3...v1.0.0
+  [0.0.3]: ${repoUrl}/compare/v0.0.2...v0.0.3
+  [0.0.2]: ${repoUrl}/compare/v0.0.1...v0.0.2
+  [0.0.1]: ${repoUrl}/releases/tag/v0.0.1
+`;
+
+/**
+ * Creates a changelog string with the given content, header, and reference links.
+ *
+ * @param header - The changelog header (default: COMMON_HEADER).
+ * @param content - The changelog content to include.
+ * @param reference - The reference links (default: COMMON_REFERENCE_LINKS).
+ * @returns The complete changelog string.
+ */
+function createChangelog(
+  header: string,
+  content: string,
+  reference: string,
+): string {
+  return `${header}\n${content}\n${reference}`;
+}
+
 describe('parseChangelog', () => {
   it('should parse empty changelog', () => {
     const changelog = parseChangelog({
@@ -37,10 +80,9 @@ describe('parseChangelog', () => {
 
         ## [Unreleased]
 
-        [Unreleased]:https://github.com/ExampleUsernameOrOrganization/ExampleRepository/
+        [Unreleased]:${repoUrl}/
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([]);
@@ -57,10 +99,9 @@ describe('parseChangelog', () => {
 
         ## [Unreleased]
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/
+        [Unreleased]: ${repoUrl}/
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([]);
@@ -74,10 +115,9 @@ describe('parseChangelog', () => {
 
         ## [Unreleased]
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/
+        [Unreleased]: ${repoUrl}/
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([]);
@@ -107,13 +147,12 @@ describe('parseChangelog', () => {
         ### Changed
         - Something
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
-        [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
-        [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/compare/v0.0.2...v1.0.0
+        [0.0.2]: ${repoUrl}/compare/v0.0.1...v0.0.2
+        [0.0.1]: ${repoUrl}/releases/tag/v0.0.1
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([
@@ -189,10 +228,9 @@ describe('parseChangelog', () => {
         ### Changed
         - Something
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([
@@ -253,13 +291,12 @@ describe('parseChangelog', () => {
         ### Changed
         - Something
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0-rc.1...HEAD
-        [1.0.0-rc.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2-beta.1...v1.0.0-rc.1
-        [0.0.2-beta.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1-alpha.1...v0.0.2-beta.1
-        [0.0.1-alpha.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1-alpha.1
+        [Unreleased]: ${repoUrl}/compare/v1.0.0-rc.1...HEAD
+        [1.0.0-rc.1]: ${repoUrl}/compare/v0.0.2-beta.1...v1.0.0-rc.1
+        [0.0.2-beta.1]: ${repoUrl}/compare/v0.0.1-alpha.1...v0.0.2-beta.1
+        [0.0.1-alpha.1]: ${repoUrl}/releases/tag/v0.0.1-alpha.1
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([
@@ -292,13 +329,12 @@ describe('parseChangelog', () => {
         ### Changed
         - Something
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
-        [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
-        [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/compare/v0.0.2...v1.0.0
+        [0.0.2]: ${repoUrl}/compare/v0.0.1...v0.0.2
+        [0.0.1]: ${repoUrl}/releases/tag/v0.0.1
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([
@@ -324,11 +360,10 @@ describe('parseChangelog', () => {
         - Something else
         Further explanation of changes
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
@@ -357,11 +392,10 @@ describe('parseChangelog', () => {
         - Something else
           - Further explanation of changes
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
@@ -391,11 +425,10 @@ describe('parseChangelog', () => {
           - Further explanation of changes
 
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
@@ -427,11 +460,10 @@ describe('parseChangelog', () => {
         ### Fixed
         - Not including newline between change categories as part of change entry
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
@@ -471,11 +503,10 @@ describe('parseChangelog', () => {
         ### Changed
         - Initial release
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
@@ -500,11 +531,10 @@ describe('parseChangelog', () => {
         ## [1.0.0] - 2020-01-01
         ### Changed
         - Something else
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+        [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([
@@ -530,13 +560,12 @@ describe('parseChangelog', () => {
       The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
       and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/
+      [Unreleased]: ${repoUrl}/
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow('Failed to find Unreleased header');
   });
@@ -554,8 +583,7 @@ describe('parseChangelog', () => {
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow('Failed to find Unreleased link reference definition');
   });
@@ -574,14 +602,13 @@ describe('parseChangelog', () => {
       ### Changed
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Unrecognized line: '## 1.0.0 - 2020-01-01'`);
   });
@@ -600,14 +627,13 @@ describe('parseChangelog', () => {
       ### Changed
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Malformed release header: '## [1.0.0 - 2020-01-01'`);
   });
@@ -626,14 +652,13 @@ describe('parseChangelog', () => {
       ### Changed
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.2.3.4...HEAD
-      [1.2.3.4]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.2.3.4
+      [Unreleased]: ${repoUrl}/compare/v1.2.3.4...HEAD
+      [1.2.3.4]: ${repoUrl}/releases/tag/v1.2.3.4
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Invalid SemVer version in release header: '## [1.2.3.4]`);
   });
@@ -652,14 +677,13 @@ describe('parseChangelog', () => {
       ### Changed
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Unrecognized line: '# [1.0.0] - 2020-01-01'`);
   });
@@ -677,14 +701,13 @@ describe('parseChangelog', () => {
       ## [1.0.0] - 2020-01-01
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Category missing for change: '- Something else'`);
   });
@@ -703,14 +726,13 @@ describe('parseChangelog', () => {
       #### Changed
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Unrecognized line: '#### Changed'`);
   });
@@ -729,14 +751,13 @@ describe('parseChangelog', () => {
       ### Ch-Ch-Ch-Ch-Changes
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Malformed category header: '### Ch-Ch-Ch-Ch-Changes'`);
   });
@@ -755,14 +776,13 @@ describe('parseChangelog', () => {
       ### Invalid
       - Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Invalid change category: 'Invalid'`);
   });
@@ -781,14 +801,13 @@ describe('parseChangelog', () => {
       ### Changed
       * Something else
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(`Unrecognized line: '* Something else'`);
   });
@@ -807,14 +826,13 @@ describe('parseChangelog', () => {
       ### Changed
       * Very very very very very very very very very very very very very very very very very very very very long line
 
-      [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-      [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v1.0.0
+      [Unreleased]: ${repoUrl}/compare/v1.0.0...HEAD
+      [1.0.0]: ${repoUrl}/releases/tag/v1.0.0
       `;
     expect(() =>
       parseChangelog({
         changelogContent: brokenChangelog,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        repoUrl,
       }),
     ).toThrow(
       `Unrecognized line: '* Very very very very very very very very very very very very very very very ver...'`,
@@ -844,13 +862,12 @@ describe('parseChangelog', () => {
         ### Changed
         - Something
 
-        [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/@metamask/test@1.0.0...HEAD
-        [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/test@0.0.2...@metamask/test@1.0.0
-        [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/test@0.0.1...test@0.0.2
-        [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/test@0.0.1
+        [Unreleased]: ${repoUrl}/compare/@metamask/test@1.0.0...HEAD
+        [1.0.0]: ${repoUrl}/compare/test@0.0.2...@metamask/test@1.0.0
+        [0.0.2]: ${repoUrl}/compare/test@0.0.1...test@0.0.2
+        [0.0.1]: ${repoUrl}/releases/tag/test@0.0.1
         `,
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+      repoUrl,
     });
 
     expect(changelog.getReleases()).toStrictEqual([
@@ -903,21 +920,14 @@ describe('parseChangelog', () => {
     expect(changelog.getUnreleasedChanges()).toStrictEqual({});
   });
 
-  describe('when shouldExtractPrLinks is true', () => {
+  describe('when shouldExtractPrLinks is true and changelog entry matches long pattern', () => {
     it('should parse changelog with pull request links after changelog entries', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something else ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+          - Change something else ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200))
 
           ## [0.0.2]
           ### Fixed
@@ -926,14 +936,13 @@ describe('parseChangelog', () => {
           ## [0.0.1]
           ### Added
           - Initial release ([#456](anything goes here actually))
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
-          [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
-          [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_3,
+      );
+
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -956,26 +965,20 @@ describe('parseChangelog', () => {
     });
 
     it('should parse changelog with pull request links at end of first line of multi-line change description', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+          - Change something ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200))
           This is a cool change, you will really like it.
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_1,
+      );
+
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -991,26 +994,19 @@ describe('parseChangelog', () => {
     });
 
     it('should parse changelog with pull request links at end of first line of change description with sub-bullets', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+          - Change something ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200))
             - This is a cool change, you will really like it.
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -1026,34 +1022,26 @@ describe('parseChangelog', () => {
     });
 
     it('should preserve links within sub-bullets', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
           - Change something
-            - This is a cool change, you will really like it. ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+            - This is a cool change, you will really like it. ([#100](${repoUrl}/pull/100))
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
       expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
         Changed: [
           {
-            description:
-              'Change something\n  - This is a cool change, you will really like it. ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))',
+            description: `Change something\n  - This is a cool change, you will really like it. ([#100](${repoUrl}/pull/100))`,
             prNumbers: [],
           },
         ],
@@ -1061,25 +1049,18 @@ describe('parseChangelog', () => {
     });
 
     it('should parse changelog with pull request links somewhere within entry, not just at end', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200)). And something else.
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+          - Change something ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200)). And something else.
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -1094,25 +1075,18 @@ describe('parseChangelog', () => {
     });
 
     it('should combine multiple pull request lists', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200)) ([#300](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/300))
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+          - Change something ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200)) ([#300](${repoUrl}/pull/300))
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -1127,25 +1101,18 @@ describe('parseChangelog', () => {
     });
 
     it('should de-duplicate pull request links in same list', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+          - Change something ([#100](${repoUrl}/pull/100), [#100](${repoUrl}/pull/100))
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -1160,25 +1127,18 @@ describe('parseChangelog', () => {
     });
 
     it('should de-duplicate pull request links in separate lists', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100)) ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100))
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
+          - Change something ([#100](${repoUrl}/pull/100)) ([#100](${repoUrl}/pull/100))
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -1193,23 +1153,16 @@ describe('parseChangelog', () => {
     });
 
     it('should preserve non-pull request links or malformed link syntax after changelog entries as part of the entry text itself', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something else ([123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))
+          - Change something else ([123](${repoUrl}))
 
           ## [0.0.3]
           ### Deprecated
-          - Deprecate whatever([#123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))
+          - Deprecate whatever([#123](${repoUrl}))
 
           ## [0.0.2]
           ### Fixed
@@ -1218,15 +1171,12 @@ describe('parseChangelog', () => {
           ## [0.0.1]
           ### Added
           - Initial release ([#789](https://example.com)
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.3...v1.0.0
-          [0.0.3]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v0.0.3
-          [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
-          [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_4,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: true,
       });
 
@@ -1234,8 +1184,7 @@ describe('parseChangelog', () => {
         Changed: [
           {
             // Missing '#'
-            description:
-              'Change something else ([123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))',
+            description: `Change something else ([123](${repoUrl}))`,
             prNumbers: [],
           },
         ],
@@ -1244,8 +1193,7 @@ describe('parseChangelog', () => {
         Deprecated: [
           {
             // Missing space before link
-            description:
-              'Deprecate whatever([#123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository))',
+            description: `Deprecate whatever([#123](${repoUrl}))`,
             prNumbers: [],
           },
         ],
@@ -1271,21 +1219,312 @@ describe('parseChangelog', () => {
     });
   });
 
-  describe('when shouldExtractPrLinks is false', () => {
-    it('should not parse pull request links after changelog entries specially', () => {
-      const changelog = parseChangelog({
-        changelogContent: outdent`
-          # Changelog
-          All notable changes to this project will be documented in this file.
-
-          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-          ## [Unreleased]
-
+  describe('when shouldExtractPrLinks is true and changelog entry matches short pattern', () => {
+    it('should parse changelog with pull request links after changelog entries', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
           ## [1.0.0]
           ### Changed
-          - Change something else ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))
+          - Change something else (#100), (#200)
+
+          ## [0.0.2]
+          ### Fixed
+          - Fix something
+
+          ## [0.0.1]
+          ### Added
+          - Initial release (#456)
+        `,
+        COMMON_REFERENCE_LINKS_3,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something else',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
+        Added: [
+          {
+            description: 'Initial release',
+            prNumbers: ['456'],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog with pull request links at end of first line of multi-line change description', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something (#100), (#200)
+          This is a cool change, you will really like it.
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description:
+              'Change something\nThis is a cool change, you will really like it.',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog with pull request links at end of first line of change description with sub-bullets', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something (#100), (#200)
+            - This is a cool change, you will really like it.
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description:
+              'Change something\n  - This is a cool change, you will really like it.',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+    });
+
+    it('should preserve links within sub-bullets', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something
+            - This is a cool change, you will really like it. (#100)
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description:
+              'Change something\n  - This is a cool change, you will really like it. (#100)',
+            prNumbers: [],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog with pull request links somewhere within entry, not just at end', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something (#100), (#200). And something else.
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something. And something else.',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+    });
+
+    it('should combine multiple pull request lists', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something (#100), (#200) (#300)
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100', '200', '300'],
+          },
+        ],
+      });
+    });
+
+    it('should de-duplicate pull request links in same list', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something (#100), (#100)
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100'],
+          },
+        ],
+      });
+    });
+
+    it('should de-duplicate pull request links in separate lists', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something (#100) (#100)
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100'],
+          },
+        ],
+      });
+    });
+
+    it('should preserve non-pull request links or malformed link syntax after changelog entries as part of the entry text itself', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something else (123)
+
+          ## [0.0.3]
+          ### Deprecated
+          - Deprecate whatever(#123)
+
+          ## [0.0.2]
+          ### Fixed
+          - Fix something
+
+          ## [0.0.1]
+          ### Added
+          - Initial release (#789
+        `,
+        COMMON_REFERENCE_LINKS_4,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            // Missing '#'
+            description: 'Change something else (123)',
+            prNumbers: [],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.3')).toStrictEqual({
+        Deprecated: [
+          {
+            // Missing space before link
+            description: 'Deprecate whatever(#123)',
+            prNumbers: [],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.2')).toStrictEqual({
+        Fixed: [
+          {
+            // Missing link
+            description: 'Fix something',
+            prNumbers: [],
+          },
+        ],
+      });
+      expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
+        Added: [
+          {
+            // Incorrect URL
+            description: 'Initial release (#789',
+            prNumbers: [],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('when shouldExtractPrLinks is false', () => {
+    it('should not parse pull request links after changelog entries specially', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something else ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200))
 
           ## [0.0.2]
           ### Fixed
@@ -1294,22 +1533,19 @@ describe('parseChangelog', () => {
           ## [0.0.1]
           ### Added
           - Initial release ([#456](anything goes here actually))
-
-          [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v1.0.0...HEAD
-          [1.0.0]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.2...v1.0.0
-          [0.0.2]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/compare/v0.0.1...v0.0.2
-          [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
         `,
-        repoUrl:
-          'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+        COMMON_REFERENCE_LINKS_3,
+      );
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
         shouldExtractPrLinks: false,
       });
 
       expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
         Changed: [
           {
-            description:
-              'Change something else ([#100](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/100), [#200](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/200))',
+            description: `Change something else ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200))`,
             prNumbers: [],
           },
         ],

--- a/src/parse-changelog.test.ts
+++ b/src/parse-changelog.test.ts
@@ -935,7 +935,7 @@ describe('parseChangelog', () => {
 
           ## [0.0.1]
           ### Added
-          - Initial release ([#456](anything goes here actually))
+          - Initial release ([#456](a PR link to the right repo is needed here, otherwise it will be ignored))
         `,
         COMMON_REFERENCE_LINKS_3,
       );
@@ -957,8 +957,9 @@ describe('parseChangelog', () => {
       expect(changelog.getReleaseChanges('0.0.1')).toStrictEqual({
         Added: [
           {
-            description: 'Initial release',
-            prNumbers: ['456'],
+            description:
+              'Initial release ([#456](a PR link to the right repo is needed here, otherwise it will be ignored))',
+            prNumbers: [],
           },
         ],
       });

--- a/src/parse-changelog.ts
+++ b/src/parse-changelog.ts
@@ -31,7 +31,7 @@ function isValidChangeCategory(category: string): category is ChangeCategory {
  * @returns The repository name, or null if it could not be determined.
  */
 function extractRepoName(repoUrl: string): string {
-  const match = repoUrl.match(/github\.com\/[^/]+\/([^/]+)/u); // Match and capture the repo name
+  const match = repoUrl?.match(/github\.com\/[^/]+\/([^/]+)/u); // Match and capture the repo name
   return match ? match[1] : '';
 }
 

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -42,3 +42,27 @@ export function getRepositoryUrl(): string | null {
 
   return null;
 }
+
+/**
+ * Extract the owner and repository name from a GitHub repository URL.
+ *
+ * Supports HTTPS and SSH GitHub URLs and removes any trailing .git; throws if parsing fails.
+ *
+ * @param repoUrl - The full GitHub repository URL (e.g., https://github.com/owner/repo or git@github.com:owner/repo).
+ * @returns An object containing the owner and repo name.
+ * @throws If the URL cannot be parsed.
+ */
+export function getOwnerAndRepoFromUrl(repoUrl: string): {
+  owner: string;
+  repo: string;
+} {
+  const match = repoUrl.match(
+    /github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/]+)$/iu,
+  );
+
+  if (!match?.groups) {
+    throw new Error(`Cannot parse owner/repo from repoUrl: ${repoUrl}`);
+  }
+
+  return { owner: match.groups.owner, repo: match.groups.repo };
+}

--- a/src/run-command.ts
+++ b/src/run-command.ts
@@ -1,0 +1,35 @@
+import execa from 'execa';
+
+/**
+ * Executes a shell command in a child process and returns what it wrote to
+ * stdout, or rejects if the process exited with an error.
+ *
+ * @param command - The command to run, e.g. "git".
+ * @param args - The arguments to the command.
+ * @returns An array of the non-empty lines returned by the command.
+ */
+export async function runCommand(
+  command: string,
+  args: string[],
+): Promise<string> {
+  return (await execa(command, [...args])).stdout;
+}
+
+/**
+ * Executes a shell command in a child process and returns what it wrote to
+ * stdout, or rejects if the process exited with an error.
+ * Trims, splits the output by newlines, and filters out empty lines.
+ *
+ * @param command - The command to run, e.g. "git".
+ * @param args - The arguments to the command.
+ * @returns An array of the non-empty lines returned by the command.
+ */
+export async function runCommandAndSplit(
+  command: string,
+  args: string[],
+): Promise<string[]> {
+  return (await execa(command, [...args])).stdout
+    .trim()
+    .split('\n')
+    .filter((line) => line !== '');
+}

--- a/src/update-changelog.test.ts
+++ b/src/update-changelog.test.ts
@@ -17,12 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 describe('updateChangelog', () => {
   it('should contain conventional support mappings categorization when autoCategorize is true', async () => {
     // Set up the spy and mock the implementation if needed
-    jest
-      .spyOn(ChangeLogUtils, 'getNewChangeEntries')
-      .mockResolvedValue([
-        'fix: Fixed a critical bug',
-        'feat: Added new feature [PR#123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/123)',
-      ]);
+    jest.spyOn(ChangeLogUtils, 'getNewChangeEntries').mockResolvedValue([
+      {
+        description: 'Fixed a critical bug (#123)',
+        subject: 'fix: Fixed a critical bug (#123)',
+      },
+      {
+        description: 'New cool feature (#124)',
+        subject: 'feat: New cool feature (#124)',
+      },
+    ]);
 
     const result = await ChangeLogManager.updateChangelog({
       changelogContent: emptyChangelog,
@@ -31,6 +35,8 @@ describe('updateChangelog', () => {
         'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
       isReleaseCandidate: true,
       autoCategorize: true,
+      useChangelogEntry: false,
+      useShortPrLink: false,
     });
 
     expect(result).toContain('### Fixed');
@@ -40,12 +46,16 @@ describe('updateChangelog', () => {
 
   it('should not contain conventional support mappings categorization when autoCategorize is false', async () => {
     // Set up the spy and mock the implementation if needed
-    jest
-      .spyOn(ChangeLogUtils, 'getNewChangeEntries')
-      .mockResolvedValue([
-        'fix: Fixed a critical bug',
-        'feat: Added new feature [PR#123](https://github.com/ExampleUsernameOrOrganization/ExampleRepository/pull/123)',
-      ]);
+    jest.spyOn(ChangeLogUtils, 'getNewChangeEntries').mockResolvedValue([
+      {
+        description: 'Fixed a critical bug (#123)',
+        subject: 'fix: Fixed a critical bug (#123)',
+      },
+      {
+        description: 'New cool feature (#124)',
+        subject: 'feat: New cool feature (#124)',
+      },
+    ]);
 
     const result = await ChangeLogManager.updateChangelog({
       changelogContent: emptyChangelog,
@@ -54,6 +64,8 @@ describe('updateChangelog', () => {
         'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
       isReleaseCandidate: true,
       autoCategorize: false,
+      useChangelogEntry: false,
+      useShortPrLink: false,
     });
 
     expect(result).toContain('### Uncategorized');

--- a/src/update-changelog.test.ts
+++ b/src/update-changelog.test.ts
@@ -14,29 +14,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/
 `;
 
+const getNewChangeEntriesMockData = [
+  {
+    description: 'Fixed a critical bug (#123)',
+    subject: 'fix: Fixed a critical bug (#123)',
+  },
+  {
+    description: 'New cool feature (#124)',
+    subject: 'feat: New cool feature (#124)',
+  },
+  {
+    description: 'Release thingy (#124)',
+    subject: 'release: Release thingy (#124)',
+  },
+];
+
+const changelogData = {
+  changelogContent: emptyChangelog,
+  currentVersion: '1.0.0',
+  repoUrl: 'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
+  isReleaseCandidate: true,
+  autoCategorize: true,
+  useChangelogEntry: false,
+  useShortPrLink: true,
+};
+
 describe('updateChangelog', () => {
   it('should contain conventional support mappings categorization when autoCategorize is true', async () => {
-    // Set up the spy and mock the implementation if needed
-    jest.spyOn(ChangeLogUtils, 'getNewChangeEntries').mockResolvedValue([
-      {
-        description: 'Fixed a critical bug (#123)',
-        subject: 'fix: Fixed a critical bug (#123)',
-      },
-      {
-        description: 'New cool feature (#124)',
-        subject: 'feat: New cool feature (#124)',
-      },
-    ]);
+    jest
+      .spyOn(ChangeLogUtils, 'getNewChangeEntries')
+      .mockResolvedValue(getNewChangeEntriesMockData);
 
     const result = await ChangeLogManager.updateChangelog({
-      changelogContent: emptyChangelog,
-      currentVersion: '1.0.0',
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
-      isReleaseCandidate: true,
+      ...changelogData,
       autoCategorize: true,
-      useChangelogEntry: false,
-      useShortPrLink: false,
     });
 
     expect(result).toContain('### Fixed');
@@ -45,32 +56,32 @@ describe('updateChangelog', () => {
   });
 
   it('should not contain conventional support mappings categorization when autoCategorize is false', async () => {
-    // Set up the spy and mock the implementation if needed
-    jest.spyOn(ChangeLogUtils, 'getNewChangeEntries').mockResolvedValue([
-      {
-        description: 'Fixed a critical bug (#123)',
-        subject: 'fix: Fixed a critical bug (#123)',
-      },
-      {
-        description: 'New cool feature (#124)',
-        subject: 'feat: New cool feature (#124)',
-      },
-    ]);
+    jest
+      .spyOn(ChangeLogUtils, 'getNewChangeEntries')
+      .mockResolvedValue(getNewChangeEntriesMockData);
 
     const result = await ChangeLogManager.updateChangelog({
-      changelogContent: emptyChangelog,
-      currentVersion: '1.0.0',
-      repoUrl:
-        'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
-      isReleaseCandidate: true,
+      ...changelogData,
       autoCategorize: false,
-      useChangelogEntry: false,
-      useShortPrLink: false,
     });
 
     expect(result).toContain('### Uncategorized');
     expect(result).not.toContain('### Fixed');
     expect(result).not.toContain('### Added');
+  });
+
+  it('should support useChangelogEntry=true', async () => {
+    jest
+      .spyOn(ChangeLogUtils, 'getNewChangeEntries')
+      .mockResolvedValue(getNewChangeEntriesMockData);
+
+    const result = await ChangeLogManager.updateChangelog({
+      ...changelogData,
+      useChangelogEntry: true,
+    });
+
+    expect(result).toContain('### Added\n- New cool feature (#124)');
+    expect(result).toContain('### Fixed\n- Fixed a critical bug (#123)');
   });
 });
 

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -230,12 +230,15 @@ export function getCategory(description: string): ChangeCategory {
 
   // Create a regex pattern that matches any of the ConventionalCommitTypes
   const typesWithPipe = conventionalCommitTypes.join('|');
-  const conventionalCommitPattern = new RegExp(`^(${typesWithPipe}).*$`, 'ui');
+  const conventionalCommitPattern = new RegExp(
+    `^(${typesWithPipe})(\\([^)]*\\))?:.*$`,
+    'ui',
+  );
 
   const match = description.match(conventionalCommitPattern);
 
   if (match) {
-    const prefix = match.length > 1 ? match[1] : undefined;
+    const prefix = match[1]?.toLowerCase(); // Always use lowercase for consistency
     switch (prefix) {
       case ConventionalCommitType.FEAT:
         return ChangeCategory.Added;

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -89,7 +89,7 @@ export type UpdateChangelogOptions = {
    */
   packageRename?: PackageRename;
   /**
-   * Whether to use `CHANGELOG entry:` from the commit body
+   * Whether to use `CHANGELOG entry:` from the commit body and the no-changelog label
    */
   useChangelogEntry: boolean;
   /**
@@ -122,7 +122,7 @@ export type UpdateChangelogOptions = {
  * An optional, which is required only in case of package renamed.
  * @param options.autoCategorize - A flag indicating whether changes should be auto-categorized
  * based on commit message prefixes.
- * @param options.useChangelogEntry - Whether to use `CHANGELOG entry:` from the commit body.
+ * @param options.useChangelogEntry - Whether to use `CHANGELOG entry:` from the commit body and the no-changelog label.
  * @param options.useShortPrLink - Whether to use short PR links in the changelog.
  * @returns The updated changelog text.
  */

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -270,11 +270,5 @@ export function getCategory(description: string): ChangeCategory {
 function checkIfDescriptionIndicatesExcluded(description: string): boolean {
   const _description = description.toLowerCase();
 
-  const keywordsToIndicateExcludedLowerCase = keywordsToIndicateExcluded.map(
-    (word) => word.toLowerCase(),
-  );
-
-  return keywordsToIndicateExcludedLowerCase.some((word) =>
-    _description.includes(word),
-  );
+  return keywordsToIndicateExcluded.some((word) => _description.includes(word));
 }

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -150,6 +150,7 @@ export async function updateChangelog({
     tagPrefix: tagPrefixes[0],
     formatter,
     packageRename,
+    shouldExtractPrLinks: true, // By setting this to true, we ensure we don't re-add a PR to the changelog if it was already added in previous releases
   });
 
   const mostRecentTag = await getMostRecentTag({
@@ -207,7 +208,7 @@ export async function updateChangelog({
     }
   }
 
-  const newChangelogContent = await changelog.toString();
+  const newChangelogContent = await changelog.toString(useShortPrLink);
   const isChangelogUpdated = changelogContent !== newChangelogContent;
   return isChangelogUpdated ? newChangelogContent : undefined;
 }
@@ -266,5 +267,11 @@ export function getCategory(description: string): ChangeCategory {
 function checkIfDescriptionIndicatesExcluded(description: string): boolean {
   const _description = description.toLowerCase();
 
-  return keywordsToIndicateExcluded.some((word) => _description.includes(word));
+  const keywordsToIndicateExcludedLowerCase = keywordsToIndicateExcluded.map(
+    (word) => word.toLowerCase(),
+  );
+
+  return keywordsToIndicateExcludedLowerCase.some((word) =>
+    _description.includes(word),
+  );
 }

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -1,6 +1,11 @@
 import type Changelog from './changelog';
 import { Formatter, getKnownPropertyNames } from './changelog';
-import { ChangeCategory, ConventionalCommitType, Version } from './constants';
+import {
+  ChangeCategory,
+  ConventionalCommitType,
+  Version,
+  keywordsToIndicateExcluded,
+} from './constants';
 import { getNewChangeEntries } from './get-new-changes';
 import { parseChangelog } from './parse-changelog';
 import { runCommandAndSplit } from './run-command';
@@ -214,8 +219,8 @@ export async function updateChangelog({
  * @returns The category of the change.
  */
 export function getCategory(description: string): ChangeCategory {
-  // Don't include merge commits in the changelog
-  if (description.startsWith('Merge')) {
+  // Check whether the commit description includes exclusion keywords
+  if (checkIfDescriptionIndicatesExcluded(description)) {
     return ChangeCategory.Excluded;
   }
 
@@ -250,4 +255,16 @@ export function getCategory(description: string): ChangeCategory {
   }
   // Return 'Uncategorized' if no colon is found or prefix doesn't match
   return ChangeCategory.Uncategorized;
+}
+
+/**
+ * Check whether the commit description includes exclusion keywords.
+ *
+ * @param description - The raw or processed commit description.
+ * @returns True if the description contains any exclusion keywords; otherwise false.
+ */
+function checkIfDescriptionIndicatesExcluded(description: string): boolean {
+  const _description = description.toLowerCase();
+
+  return keywordsToIndicateExcluded.some((word) => _description.includes(word));
 }

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -231,7 +231,7 @@ export function getCategory(description: string): ChangeCategory {
   // Create a regex pattern that matches any of the ConventionalCommitTypes
   const typesWithPipe = conventionalCommitTypes.join('|');
   const conventionalCommitPattern = new RegExp(
-    `^(${typesWithPipe})(\\([^)]*\\))?:.*$`,
+    `^(${typesWithPipe})\\s*(\\([^)]*\\))?:.*$`,
     'ui',
   );
 

--- a/src/validate-changelog.test.ts
+++ b/src/validate-changelog.test.ts
@@ -806,6 +806,8 @@ describe('validateChangelog', () => {
         [0.0.1]: https://github.com/ExampleUsernameOrOrganization/ExampleRepository/releases/tag/v0.0.1
       `;
 
+      // The links to other repos are not recognized as PR links, which is why in this example
+      // the error is about 'missing PR link', not invalid one.
       await expect(
         validateChangelog({
           changelogContent,
@@ -815,7 +817,9 @@ describe('validateChangelog', () => {
           isReleaseCandidate: false,
           ensureValidPrLinksPresent: true,
         }),
-      ).rejects.toThrow('Changelog is not well-formatted');
+      ).rejects.toThrow(
+        `Pull request link(s) missing for change: 'Fix something ([#123](https://github.com/foo/bar/pull/123))' (in 0.0.2)`,
+      );
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,6 +847,7 @@ __metadata:
     "@types/cross-spawn": ^6.0.2
     "@types/diff": ^5.0.0
     "@types/jest": ^26.0.23
+    "@types/node": ^22.18.0
     "@types/semver": ^7.3.6
     "@types/yargs": ^16.0.1
     "@typescript-eslint/eslint-plugin": ^5.42.1
@@ -1322,6 +1323,15 @@ __metadata:
   version: 20.1.1
   resolution: "@types/node@npm:20.1.1"
   checksum: 47961ee23f873c14c3f6045422ff3059f3bfb10231ef3080a7a72d7215cc8c2623fa8cedb7b246305962fa9c1e0c9e381e04b12eb3e9ec5d076025c6231ac8da
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.18.0":
+  version: 22.18.0
+  resolution: "@types/node@npm:22.18.0"
+  dependencies:
+    undici-types: ~6.21.0
+  checksum: a110b66f079ea882be1e300e72978cd3a5e7be8217b362b72152e09f64087731a235a0557fca72d621912a8ba1347d9ba49468c35755dd2581edb7f3f6e016e2
   languageName: node
   linkType: hard
 
@@ -6261,6 +6271,13 @@ __metadata:
     has-symbols: ^1.0.3
     which-boxed-primitive: ^1.0.2
   checksum: b7a1cf5862b5e4b5deb091672ffa579aa274f648410009c81cca63fed3b62b610c4f3b773f912ce545bb4e31edc3138975b5bc777fc6e4817dca51affb6380e9
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 46331c7d6016bf85b3e8f20c159d62f5ae471aba1eb3dc52fff35a0259d58dcc7d592d4cc4f00c5f9243fa738a11cfa48bd20203040d4a9e6bc25e807fab7ab3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,7 +842,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.1.0
     "@metamask/eslint-config-nodejs": ^11.1.0
     "@metamask/eslint-config-typescript": ^11.1.0
-    "@octokit/rest": ^22.0.0
+    "@octokit/rest": ^20.0.0
     "@ts-bridge/cli": ^0.6.3
     "@types/cross-spawn": ^6.0.2
     "@types/diff": ^5.0.0
@@ -1001,127 +1001,128 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/auth-token@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@octokit/auth-token@npm:6.0.0"
-  checksum: 9c23be526c7f8e282aa7ccec6f3a72a1beec44eae736327e9ba78419fa28ba75e2c686e9eac75f35ce99bdb55eff9605f7ef7588a9d4f4e18ad5ed16a5d887ab
+"@octokit/auth-token@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@octokit/auth-token@npm:4.0.0"
+  checksum: d78f4dc48b214d374aeb39caec4fdbf5c1e4fd8b9fcb18f630b1fe2cbd5a880fca05445f32b4561f41262cb551746aeb0b49e89c95c6dd99299706684d0cae2f
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^7.0.2":
-  version: 7.0.3
-  resolution: "@octokit/core@npm:7.0.3"
+"@octokit/core@npm:^5.0.2":
+  version: 5.2.2
+  resolution: "@octokit/core@npm:5.2.2"
   dependencies:
-    "@octokit/auth-token": ^6.0.0
-    "@octokit/graphql": ^9.0.1
-    "@octokit/request": ^10.0.2
-    "@octokit/request-error": ^7.0.0
-    "@octokit/types": ^14.0.0
-    before-after-hook: ^4.0.0
-    universal-user-agent: ^7.0.0
-  checksum: c7ce57b38b18175ffc09a642a4d52716eb2e9f2071312b1d4a968104eebdc38e7f89f3d2a02980df1eea04b263d3666cfb1d8ec2a2db6148ad43a20ee4e0d6b0
+    "@octokit/auth-token": ^4.0.0
+    "@octokit/graphql": ^7.1.0
+    "@octokit/request": ^8.4.1
+    "@octokit/request-error": ^5.1.1
+    "@octokit/types": ^13.0.0
+    before-after-hook: ^2.2.0
+    universal-user-agent: ^6.0.0
+  checksum: d4303d808c6b8eca32ce03381db5f6230440c1c6cfd9d73376ed583973094abd8ca56d9a64d490e6b0045f827a8f913b619bd90eae99c2cba682487720dc8002
   languageName: node
   linkType: hard
 
-"@octokit/endpoint@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "@octokit/endpoint@npm:11.0.0"
+"@octokit/endpoint@npm:^9.0.6":
+  version: 9.0.6
+  resolution: "@octokit/endpoint@npm:9.0.6"
   dependencies:
-    "@octokit/types": ^14.0.0
-    universal-user-agent: ^7.0.2
-  checksum: 1c4bd71b3041bf935535c13e9636cb9846469655050583e0ad2595f2f1f840eba2a3f5f43a0dbc82fd695ad0124ab4fc389a2ef3d0770d642fed717e31e4300f
+    "@octokit/types": ^13.1.0
+    universal-user-agent: ^6.0.0
+  checksum: f853c08f0777a8cc7c3d2509835d478e11a76d722f807d4f2ad7c0e64bf4dd159536409f466b367a907886aa3b78574d3d09ed95ac462c769e4fccaaad81e72a
   languageName: node
   linkType: hard
 
-"@octokit/graphql@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "@octokit/graphql@npm:9.0.1"
+"@octokit/graphql@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "@octokit/graphql@npm:7.1.1"
   dependencies:
-    "@octokit/request": ^10.0.2
-    "@octokit/types": ^14.0.0
-    universal-user-agent: ^7.0.0
-  checksum: 3d59773cf56333be8668f7708c473f5746ad49552c0e542ae32c0442e0f16c4b6389408c8868f211b45d0292f1ebfdc92160ee6c2cbf12c5fa0d9a938713bcf9
+    "@octokit/request": ^8.4.1
+    "@octokit/types": ^13.0.0
+    universal-user-agent: ^6.0.0
+  checksum: afb60d5dda6d365334480540610d67b0c5f8e3977dd895fe504ce988f8b7183f29f3b16b88d895a701a739cf29d157d49f8f9fbc71b6c57eb4fc9bd97e099f55
   languageName: node
   linkType: hard
 
-"@octokit/openapi-types@npm:^25.1.0":
-  version: 25.1.0
-  resolution: "@octokit/openapi-types@npm:25.1.0"
-  checksum: 441b17f801254629b3ddb4b878c589fee1fd23015253c8b72a3acb3eeedbe981691bb311649ab5f955005c5d7adb940f19e18eaf0c875752fe0cc12b3dc1d24b
+"@octokit/openapi-types@npm:^24.2.0":
+  version: 24.2.0
+  resolution: "@octokit/openapi-types@npm:24.2.0"
+  checksum: 3c2d2f4cafd21c8a1e6a6fe6b56df6a3c09bc52ab6f829c151f9397694d028aa183ae856f08e006ee7ecaa7bd7eb413a903fbc0ffa6403e7b284ddcda20b1294
   languageName: node
   linkType: hard
 
-"@octokit/plugin-paginate-rest@npm:^13.0.1":
-  version: 13.1.1
-  resolution: "@octokit/plugin-paginate-rest@npm:13.1.1"
+"@octokit/plugin-paginate-rest@npm:11.4.4-cjs.2":
+  version: 11.4.4-cjs.2
+  resolution: "@octokit/plugin-paginate-rest@npm:11.4.4-cjs.2"
   dependencies:
-    "@octokit/types": ^14.1.0
+    "@octokit/types": ^13.7.0
   peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 5c99c4f84672b3447b62025111b9dc08f4cdff80713f5b3fb15a518b22f2dcfafb36d8b13892847ee0daddf22e2b2163934a64ba3b53e8e965bd4312d24fb4d6
+    "@octokit/core": 5
+  checksum: e6d1f4da255d08c24188b5df1436f22680e7fe2608d3af5d2f08a98f40d565bd3df0c58d306f05caae923247fffe861ec12d5f1273a882333fcdb34255e6c8b0
   languageName: node
   linkType: hard
 
-"@octokit/plugin-request-log@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@octokit/plugin-request-log@npm:6.0.0"
+"@octokit/plugin-request-log@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@octokit/plugin-request-log@npm:4.0.1"
   peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 8a79973b1429bfead9113c4117f418aaef5ff368795daded3415ba14623d97d5fc08d1e822dbd566ecc9f041119e1a48a11853a9c48d9eb1caa62baa79c17f83
+    "@octokit/core": 5
+  checksum: fd8c0a201490cba00084689a0d1d54fc7b5ab5b6bdb7e447056b947b1754f78526e9685400eab10d3522bfa7b5bc49c555f41ec412c788610b96500b168f3789
   languageName: node
   linkType: hard
 
-"@octokit/plugin-rest-endpoint-methods@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "@octokit/plugin-rest-endpoint-methods@npm:16.0.0"
+"@octokit/plugin-rest-endpoint-methods@npm:13.3.2-cjs.1":
+  version: 13.3.2-cjs.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:13.3.2-cjs.1"
   dependencies:
-    "@octokit/types": ^14.1.0
+    "@octokit/types": ^13.8.0
   peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 8ebb30b41628b839cca0b1051459f92001db37f4c3b8a87551915cdf5707d9e87f300565795ca2c12b5767b0d294b15bb0cd1ab3da99620c82690b37eddbd635
+    "@octokit/core": ^5
+  checksum: de38a7fe33aa41ecfa62dd8546d9b603cf43b1a6cf3a31e8c1950684e1cf0f9dc7ccbcff8ef570e825729f3800f42e6ae33447c836dfa12259391ced421df64f
   languageName: node
   linkType: hard
 
-"@octokit/request-error@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "@octokit/request-error@npm:7.0.0"
+"@octokit/request-error@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@octokit/request-error@npm:5.1.1"
   dependencies:
-    "@octokit/types": ^14.0.0
-  checksum: c4370d2c31f599c1f366c480d5a02bc93442e5a0e151ec5caf0d5a5b0f0f91b50ecedc945aa6ea61b4c9ed1e89153dc7727daf4317680d33e916f829da7d141b
+    "@octokit/types": ^13.1.0
+    deprecation: ^2.0.0
+    once: ^1.4.0
+  checksum: 17d0b3f59c2a8a285715bfe6a85168d9c417aa7a0ff553b9be4198a3bc8bb00384a3530221a448eb19f8f07ea9fc48d264869624f5f84fa63a948a7af8cddc8c
   languageName: node
   linkType: hard
 
-"@octokit/request@npm:^10.0.2":
-  version: 10.0.3
-  resolution: "@octokit/request@npm:10.0.3"
+"@octokit/request@npm:^8.4.1":
+  version: 8.4.1
+  resolution: "@octokit/request@npm:8.4.1"
   dependencies:
-    "@octokit/endpoint": ^11.0.0
-    "@octokit/request-error": ^7.0.0
-    "@octokit/types": ^14.0.0
-    fast-content-type-parse: ^3.0.0
-    universal-user-agent: ^7.0.2
-  checksum: f9815898fd372deaf9296502225dca1208fdaf3c07574fb7adf83dd1dd4e5f327254ff1f67e93fbda995311386da470f4534fdf31ea034dd9c88b34bd1936240
+    "@octokit/endpoint": ^9.0.6
+    "@octokit/request-error": ^5.1.1
+    "@octokit/types": ^13.1.0
+    universal-user-agent: ^6.0.0
+  checksum: 0ba76728583543baeef9fda98690bc86c57e0a3ccac8c189d2b7d144d248c89167eb37a071ed8fead8f4da0a1c55c4dd98a8fc598769c263b95179fb200959de
   languageName: node
   linkType: hard
 
-"@octokit/rest@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "@octokit/rest@npm:22.0.0"
+"@octokit/rest@npm:^20.0.0":
+  version: 20.1.2
+  resolution: "@octokit/rest@npm:20.1.2"
   dependencies:
-    "@octokit/core": ^7.0.2
-    "@octokit/plugin-paginate-rest": ^13.0.1
-    "@octokit/plugin-request-log": ^6.0.0
-    "@octokit/plugin-rest-endpoint-methods": ^16.0.0
-  checksum: 6a7eff019c0889b23c0820831936e5dc8fa7643bdf0e98ba073b36a10f5602b9f283ca2c74ec8172b8529d0647dfa4a7857dcd81ca028b303937f26750a6c7f6
+    "@octokit/core": ^5.0.2
+    "@octokit/plugin-paginate-rest": 11.4.4-cjs.2
+    "@octokit/plugin-request-log": ^4.0.0
+    "@octokit/plugin-rest-endpoint-methods": 13.3.2-cjs.1
+  checksum: 72309dd393f3424f0c4213d045332c1c1a00893bea4db9b54d6add7316d9a9b461932de3afe3c866bff52cc084c79e98f644dabd386cda95068690cc9ae97456
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^14.0.0, @octokit/types@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "@octokit/types@npm:14.1.0"
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
+  version: 13.10.0
+  resolution: "@octokit/types@npm:13.10.0"
   dependencies:
-    "@octokit/openapi-types": ^25.1.0
-  checksum: 0513520e26dc5395c3b3b407568151d32be1f51bedb151f5b294cadc72dc3fe2d0dbbccad96f01dc80d26247b4aed3358de0ce31ad3c013eb22b96e6234feeb5
+    "@octokit/openapi-types": ^24.2.0
+  checksum: fca3764548d5872535b9025c3b5fe6373fe588b287cb5b5259364796c1931bbe5e9ab8a86a5274ce43bb2b3e43b730067c3b86b6b1ade12a98cd59b2e8b3610d
   languageName: node
   linkType: hard
 
@@ -1860,10 +1861,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"before-after-hook@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "before-after-hook@npm:4.0.0"
-  checksum: a8cbd4d3c48f42f44307ef5966be152b836d2e5908834f2f885ddf104c2e2ba66dbb5e6ef89a37e77371b1d22d5c75b74df1472286c684a037c1a6db43f5617b
+"before-after-hook@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "before-after-hook@npm:2.2.3"
+  checksum: a1a2430976d9bdab4cd89cb50d27fa86b19e2b41812bf1315923b0cba03371ebca99449809226425dd3bcef20e010db61abdaff549278e111d6480034bebae87
   languageName: node
   linkType: hard
 
@@ -2360,6 +2361,13 @@ __metadata:
   version: 1.1.2
   resolution: "depd@npm:1.1.2"
   checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
+  languageName: node
+  linkType: hard
+
+"deprecation@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "deprecation@npm:2.3.1"
+  checksum: f56a05e182c2c195071385455956b0c4106fe14e36245b00c689ceef8e8ab639235176a96977ba7c74afb173317fac2e0ec6ec7a1c6d1e6eaa401c586c714132
   languageName: node
   linkType: hard
 
@@ -2946,13 +2954,6 @@ __metadata:
   version: 1.4.0
   resolution: "extsprintf@npm:1.4.0"
   checksum: 184dc8a413eb4b1ff16bdce797340e7ded4d28511d56a1c9afa5a95bcff6ace154063823eaf0206dbbb0d14059d74f382a15c34b7c0636fa74a7e681295eb67e
-  languageName: node
-  linkType: hard
-
-"fast-content-type-parse@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "fast-content-type-parse@npm:3.0.0"
-  checksum: 490199423215b8a9c6e24a5a01a0d072af8ebfe24c13deac0a393dcac36b732295dd8cec5a2c4241249ed0fffc6983ba138f3001b13286afefb66360b6715a46
   languageName: node
   linkType: hard
 
@@ -5036,7 +5037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -6288,10 +6289,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
-  version: 7.0.3
-  resolution: "universal-user-agent@npm:7.0.3"
-  checksum: c497e85f8b11eb8fa4dce584d7a39cc98710164959f494cafc3c269b51abb20fff269951838efd7424d15f6b3d001507f3cb8b52bb5676fdb642019dfd17e63e
+"universal-user-agent@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "universal-user-agent@npm:6.0.1"
+  checksum: fdc8e1ae48a05decfc7ded09b62071f571c7fe0bd793d700704c80cea316101d4eac15cc27ed2bb64f4ce166d2684777c3198b9ab16034f547abea0d3aa1c93c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,6 +842,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^11.1.0
     "@metamask/eslint-config-nodejs": ^11.1.0
     "@metamask/eslint-config-typescript": ^11.1.0
+    "@octokit/rest": ^22.0.0
     "@ts-bridge/cli": ^0.6.3
     "@types/cross-spawn": ^6.0.2
     "@types/diff": ^5.0.0
@@ -997,6 +998,130 @@ __metadata:
     node-gyp: ^7.1.0
     read-package-json-fast: ^2.0.1
   checksum: 734f7d4bec07d723276e0351d180a83735313823685c5c79b1f56e32d77622e1bd0c5cd0fbeca9649f1e559212a4ccc8e450b1f3d6dea9cadabb442f1f13bfe8
+  languageName: node
+  linkType: hard
+
+"@octokit/auth-token@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@octokit/auth-token@npm:6.0.0"
+  checksum: 9c23be526c7f8e282aa7ccec6f3a72a1beec44eae736327e9ba78419fa28ba75e2c686e9eac75f35ce99bdb55eff9605f7ef7588a9d4f4e18ad5ed16a5d887ab
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^7.0.2":
+  version: 7.0.3
+  resolution: "@octokit/core@npm:7.0.3"
+  dependencies:
+    "@octokit/auth-token": ^6.0.0
+    "@octokit/graphql": ^9.0.1
+    "@octokit/request": ^10.0.2
+    "@octokit/request-error": ^7.0.0
+    "@octokit/types": ^14.0.0
+    before-after-hook: ^4.0.0
+    universal-user-agent: ^7.0.0
+  checksum: c7ce57b38b18175ffc09a642a4d52716eb2e9f2071312b1d4a968104eebdc38e7f89f3d2a02980df1eea04b263d3666cfb1d8ec2a2db6148ad43a20ee4e0d6b0
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "@octokit/endpoint@npm:11.0.0"
+  dependencies:
+    "@octokit/types": ^14.0.0
+    universal-user-agent: ^7.0.2
+  checksum: 1c4bd71b3041bf935535c13e9636cb9846469655050583e0ad2595f2f1f840eba2a3f5f43a0dbc82fd695ad0124ab4fc389a2ef3d0770d642fed717e31e4300f
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@octokit/graphql@npm:9.0.1"
+  dependencies:
+    "@octokit/request": ^10.0.2
+    "@octokit/types": ^14.0.0
+    universal-user-agent: ^7.0.0
+  checksum: 3d59773cf56333be8668f7708c473f5746ad49552c0e542ae32c0442e0f16c4b6389408c8868f211b45d0292f1ebfdc92160ee6c2cbf12c5fa0d9a938713bcf9
+  languageName: node
+  linkType: hard
+
+"@octokit/openapi-types@npm:^25.1.0":
+  version: 25.1.0
+  resolution: "@octokit/openapi-types@npm:25.1.0"
+  checksum: 441b17f801254629b3ddb4b878c589fee1fd23015253c8b72a3acb3eeedbe981691bb311649ab5f955005c5d7adb940f19e18eaf0c875752fe0cc12b3dc1d24b
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^13.0.1":
+  version: 13.1.1
+  resolution: "@octokit/plugin-paginate-rest@npm:13.1.1"
+  dependencies:
+    "@octokit/types": ^14.1.0
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 5c99c4f84672b3447b62025111b9dc08f4cdff80713f5b3fb15a518b22f2dcfafb36d8b13892847ee0daddf22e2b2163934a64ba3b53e8e965bd4312d24fb4d6
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-request-log@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@octokit/plugin-request-log@npm:6.0.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 8a79973b1429bfead9113c4117f418aaef5ff368795daded3415ba14623d97d5fc08d1e822dbd566ecc9f041119e1a48a11853a9c48d9eb1caa62baa79c17f83
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:16.0.0"
+  dependencies:
+    "@octokit/types": ^14.1.0
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 8ebb30b41628b839cca0b1051459f92001db37f4c3b8a87551915cdf5707d9e87f300565795ca2c12b5767b0d294b15bb0cd1ab3da99620c82690b37eddbd635
+  languageName: node
+  linkType: hard
+
+"@octokit/request-error@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@octokit/request-error@npm:7.0.0"
+  dependencies:
+    "@octokit/types": ^14.0.0
+  checksum: c4370d2c31f599c1f366c480d5a02bc93442e5a0e151ec5caf0d5a5b0f0f91b50ecedc945aa6ea61b4c9ed1e89153dc7727daf4317680d33e916f829da7d141b
+  languageName: node
+  linkType: hard
+
+"@octokit/request@npm:^10.0.2":
+  version: 10.0.3
+  resolution: "@octokit/request@npm:10.0.3"
+  dependencies:
+    "@octokit/endpoint": ^11.0.0
+    "@octokit/request-error": ^7.0.0
+    "@octokit/types": ^14.0.0
+    fast-content-type-parse: ^3.0.0
+    universal-user-agent: ^7.0.2
+  checksum: f9815898fd372deaf9296502225dca1208fdaf3c07574fb7adf83dd1dd4e5f327254ff1f67e93fbda995311386da470f4534fdf31ea034dd9c88b34bd1936240
+  languageName: node
+  linkType: hard
+
+"@octokit/rest@npm:^22.0.0":
+  version: 22.0.0
+  resolution: "@octokit/rest@npm:22.0.0"
+  dependencies:
+    "@octokit/core": ^7.0.2
+    "@octokit/plugin-paginate-rest": ^13.0.1
+    "@octokit/plugin-request-log": ^6.0.0
+    "@octokit/plugin-rest-endpoint-methods": ^16.0.0
+  checksum: 6a7eff019c0889b23c0820831936e5dc8fa7643bdf0e98ba073b36a10f5602b9f283ca2c74ec8172b8529d0647dfa4a7857dcd81ca028b303937f26750a6c7f6
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^14.0.0, @octokit/types@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "@octokit/types@npm:14.1.0"
+  dependencies:
+    "@octokit/openapi-types": ^25.1.0
+  checksum: 0513520e26dc5395c3b3b407568151d32be1f51bedb151f5b294cadc72dc3fe2d0dbbccad96f01dc80d26247b4aed3358de0ce31ad3c013eb22b96e6234feeb5
   languageName: node
   linkType: hard
 
@@ -1732,6 +1857,13 @@ __metadata:
   dependencies:
     tweetnacl: ^0.14.3
   checksum: 4edfc9fe7d07019609ccf797a2af28351736e9d012c8402a07120c4453a3b789a15f2ee1530dc49eee8f7eb9379331a8dd4b3766042b9e502f74a68e7f662291
+  languageName: node
+  linkType: hard
+
+"before-after-hook@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "before-after-hook@npm:4.0.0"
+  checksum: a8cbd4d3c48f42f44307ef5966be152b836d2e5908834f2f885ddf104c2e2ba66dbb5e6ef89a37e77371b1d22d5c75b74df1472286c684a037c1a6db43f5617b
   languageName: node
   linkType: hard
 
@@ -2814,6 +2946,13 @@ __metadata:
   version: 1.4.0
   resolution: "extsprintf@npm:1.4.0"
   checksum: 184dc8a413eb4b1ff16bdce797340e7ded4d28511d56a1c9afa5a95bcff6ace154063823eaf0206dbbb0d14059d74f382a15c34b7c0636fa74a7e681295eb67e
+  languageName: node
+  linkType: hard
+
+"fast-content-type-parse@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "fast-content-type-parse@npm:3.0.0"
+  checksum: 490199423215b8a9c6e24a5a01a0d072af8ebfe24c13deac0a393dcac36b732295dd8cec5a2c4241249ed0fffc6983ba138f3001b13286afefb66360b6715a46
   languageName: node
   linkType: hard
 
@@ -6146,6 +6285,13 @@ __metadata:
   dependencies:
     imurmurhash: ^0.1.4
   checksum: 49f8d915ba7f0101801b922062ee46b7953256c93ceca74303bd8e6413ae10aa7e8216556b54dc5382895e8221d04f1efaf75f945c2e4a515b4139f77aa6640c
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
+  version: 7.0.3
+  resolution: "universal-user-agent@npm:7.0.3"
+  checksum: c497e85f8b11eb8fa4dce584d7a39cc98710164959f494cafc3c269b51abb20fff269951838efd7424d15f6b3d001507f3cb8b52bb5676fdb642019dfd17e63e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Progresses: MetaMask/MetaMask-planning#5686

- Looks for `CHANGELOG entry:` in the PR description, and looks for `no-changelog` label, then applies this to the generated CHANGELOG
- Properly categorizes by Conventional Commit type, including our custom `ConventionalCommitType.RELEASE`

New parameters added:
- useChangelogEntry: boolean;
- useShortPrLink: boolean;
