### PR TITLE
fix: make useChangelogEntry and useShortPrLink optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ or
 
 `yarn run auto-changelog update --autoCategorize`
 
+#### Read the "CHANGELOG entry:" on the PR
+
+`yarn run auto-changelog update --useChangelogEntry`
+
+#### Use Short PR links
+
+- Like `(#247)` instead of `([#247](https://github.com/MetaMask/auto-changelog/pull/247))`
+
+`yarn run auto-changelog update --useShortPrLink`
+
 #### Update the current release section of the changelog
 
 `yarn run auto-changelog update --rc`
@@ -35,6 +45,10 @@ or
 or
 
 `npm run auto-changelog update --rc`
+
+### Deluxe, as used in metamask-extension
+
+`yarn run auto-changelog update --autoCategorize --useChangelogEntry --useShortPrLink --rc`
 
 #### Update the changelog for a renamed package
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --clean",
-    "changelog": "node dist/cli.js",
+    "changelog": "node dist/cli.mjs",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",

--- a/src/update-changelog.test.ts
+++ b/src/update-changelog.test.ts
@@ -83,6 +83,21 @@ describe('updateChangelog', () => {
     expect(result).toContain('### Added\n- New cool feature (#124)');
     expect(result).toContain('### Fixed\n- Fixed a critical bug (#123)');
   });
+
+  it('should have default values for useChangelogEntry and useShortPrLink', async () => {
+    jest
+      .spyOn(ChangeLogUtils, 'getNewChangeEntries')
+      .mockResolvedValue(getNewChangeEntriesMockData);
+
+    const result = await ChangeLogManager.updateChangelog({
+      ...changelogData,
+      useChangelogEntry: undefined,
+      useShortPrLink: undefined,
+    });
+
+    expect(result).toContain('### Added\n- New cool feature (#124)');
+    expect(result).toContain('### Fixed\n- Fixed a critical bug (#123)');
+  });
 });
 
 describe('getCategory', () => {

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -96,11 +96,11 @@ export type UpdateChangelogOptions = {
   /**
    * Whether to use `CHANGELOG entry:` from the commit body and the no-changelog label
    */
-  useChangelogEntry: boolean;
+  useChangelogEntry?: boolean;
   /**
    * Whether to use short PR links in the changelog entries.
    */
-  useShortPrLink: boolean;
+  useShortPrLink?: boolean;
 };
 
 /**
@@ -141,8 +141,8 @@ export async function updateChangelog({
   formatter = undefined,
   packageRename,
   autoCategorize,
-  useChangelogEntry,
-  useShortPrLink,
+  useChangelogEntry = false,
+  useShortPrLink = false,
 }: UpdateChangelogOptions): Promise<string | undefined> {
   const changelog = parseChangelog({
     changelogContent,


### PR DESCRIPTION
Fixes 3 issues:

1. In the TypeScript API, the new options `useChangelogEntry` and `useShortPrLink` are now optional
2. Fixes the script called "changelog" by changing it from `node dist/cli.js` to `node dist/cli.mjs`
3. Added documentation to README.md for the new options