### PR TITLE
fix: Force fetch tags

### DIFF
--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -24,8 +24,8 @@ async function getMostRecentTag({
 }: {
   tagPrefixes: [string, ...string[]];
 }) {
-  // Ensure we have all tags on remote
-  await runCommandAndSplit('git', ['fetch', '--tags']);
+  // Ensure we have all tags on remote (overwrite if necessary)
+  await runCommandAndSplit('git', ['fetch', '--tags', '--force']);
 
   let mostRecentTagCommitHash: string | null = null;
   for (const tagPrefix of tagPrefixes) {


### PR DESCRIPTION
Quite often developers run into problems with the tag fetching step where the solution is to run `git fetch --tags --force` to overwrite local tags. This PR defaults to append `--force` and overwrite local tags.

Feedback welcome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to the git invocation used during changelog updates; main risk is overwriting local tag refs in environments where that is unexpected.
> 
> **Overview**
> `getMostRecentTag` now runs `git fetch --tags --force` instead of `git fetch --tags`, ensuring local tags are overwritten before determining the most recent release tag for changelog generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1adb67eac25ec32f931108ffddd23b17c732674b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->