### PR TITLE
fix: swap diff order in validate to show expected changes correctly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -234,7 +234,7 @@ async function validate({
         return undefined;
       }
 
-      const diff = generateDiff(validChangelog, invalidChangelog);
+      const diff = generateDiff(invalidChangelog, validChangelog);
       return exitWithError(`Changelog not well-formatted. Diff:\n\n${diff}`);
     } else if (error instanceof InvalidChangelogError) {
       return exitWithError(`Changelog is invalid: ${error.message}`);


### PR DESCRIPTION
## Summary

Fixes #216

The `generateDiff` call in the `validate` command had its arguments swapped:

```ts
// Before (wrong): valid as "old", invalid as "new"
const diff = generateDiff(validChangelog, invalidChangelog);

// After (correct): invalid as "old", valid as "new"  
const diff = generateDiff(invalidChangelog, validChangelog);

This caused the diff output to be backwards — - lines showed the correct content and + lines showed the invalid content. Now the diff reads naturally: - for what you have (invalid), + for what it should be (valid).

Test plan
 All existing tests pass (4 pre-existing failures in update-changelog.test.ts are unrelated)
Manual verification: run auto-changelog validate on a malformed changelog and confirm -/+ lines are in the correct order



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change that only affects the `validate` command’s error diff output, with no impact on changelog parsing or file writes.
> 
> **Overview**
> Fixes the `validate` command’s formatting error output by swapping the argument order passed to `generateDiff`, so the displayed diff now shows the *current invalid changelog* as removals (`-`) and the *expected formatted changelog* as additions (`+`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98c6537421c50727a843b20fe8f5969df4afdbec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->