### PR TITLE
fix: use last PR number in commit subject for revert commits

### DIFF
--- a/src/get-new-changes.test.ts
+++ b/src/get-new-changes.test.ts
@@ -210,6 +210,33 @@ describe('getNewChangeEntries', () => {
     });
   });
 
+  describe('revert commits', () => {
+    it('should use the last PR number for revert commits that reference the original PR', async () => {
+      mockRunCommandAndSplit.mockResolvedValueOnce(['commit1']);
+      mockRunCommand.mockResolvedValueOnce(
+        'Revert "Remove useRequestQueue toggle (#4941)" (#5065)',
+      );
+
+      const result = await getNewChangeEntries({
+        mostRecentTag: 'v1.0.0',
+        repoUrl,
+        loggedPrNumbers: ['4941'],
+        loggedDescriptions: [],
+        useChangelogEntry: false,
+        useShortPrLink: false,
+      });
+
+      expect(result).toStrictEqual([
+        {
+          description:
+            'Revert "Remove useRequestQueue toggle (#4941)" ([#5065](https://github.com/MetaMask/metamask-mobile/pull/5065))',
+          subject:
+            'Revert "Remove useRequestQueue toggle (#4941)" (#5065)',
+        },
+      ]);
+    });
+  });
+
   describe('edge cases', () => {
     it('should return empty array when there are no commits', async () => {
       mockRunCommandAndSplit.mockResolvedValueOnce([]);

--- a/src/get-new-changes.ts
+++ b/src/get-new-changes.ts
@@ -118,7 +118,10 @@ async function getCommits(
       );
     }
 
-    const subjectMatch = subject.match(/\(#(\d+)\)/u);
+    const subjectMatches = [...subject.matchAll(/\(#(\d+)\)/gu)];
+    const subjectMatch = subjectMatches.length > 0
+      ? subjectMatches[subjectMatches.length - 1]
+      : null;
 
     let prNumber: string | undefined;
     let description = subject;


### PR DESCRIPTION
## Summary

Fixes #213

When a revert commit includes the original PR number in its quoted title, the regex matched the **first** `(#NNNN)` instead of the actual revert PR number:


Revert "Remove useRequestQueue toggle (#4941)" (#5065)
^^^^^ ^^^^^
matched ignored (actual PR)


This caused the revert commit to be filtered out as a duplicate because `#4941` was already in the changelog from a previous release.

### Fix

Changed `subject.match(/\(#(\d+)\)/u)` (returns first match) to `subject.matchAll()` + take the last match. GitHub always appends the actual PR number at the end of the subject on squash merge, so the last `(#NNNN)` is always the correct one.

### Test

Added a dedicated test case that simulates a revert commit with the original PR already logged — confirms the revert is now correctly included with its own PR number.

## Test plan

- [x] All 14 `get-new-changes` tests pass (including new revert test)
- [x] Existing tests unaffected — normal commits still extract PR number correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, targeted change to PR-number extraction from git commit subjects plus a focused unit test; main risk is altered parsing for unusual subjects containing multiple `(#NNNN)` patterns.
> 
> **Overview**
> Fixes PR-number extraction in `getNewChangeEntries` to use the **last** `(#NNNN)` occurrence in a commit subject (via `matchAll`), preventing revert commits that mention the original PR from being mis-identified and incorrectly deduplicated.
> 
> Adds a unit test covering a revert subject like `Revert "... (#4941)" (#5065)` to ensure the revert PR (`#5065`) is kept even when the original PR is already logged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8ef164fc31ef06c0dfc082d9bdb1eec6a487bf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->