### PR TITLE
fix: reject Uncategorized heading in any release during validation

### DIFF
--- a/src/validate-changelog.test.ts
+++ b/src/validate-changelog.test.ts
@@ -563,36 +563,36 @@ describe('validateChangelog', () => {
       ).resolves.not.toThrow();
     });
 
-    it('should not throw if there are uncategorized changes in the current release', async () => {
-      const changelogWithUnreleasedChanges = changelogWithReleases.replace(
+    it('should throw if there are uncategorized changes in the current release', async () => {
+      const changelogWithUncategorizedChanges = changelogWithReleases.replace(
         '## [1.0.0] - 2020-01-01',
         '## [1.0.0] - 2020-01-01\n### Uncategorized\n- More changes\n',
       );
       await expect(
         validateChangelog({
-          changelogContent: changelogWithUnreleasedChanges,
+          changelogContent: changelogWithUncategorizedChanges,
           currentVersion: '1.0.0',
           repoUrl:
             'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
           isReleaseCandidate: false,
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toThrow('Uncategorized changes present in the changelog');
     });
 
-    it('should not throw if there are uncategorized changes in an older release', async () => {
-      const changelogWithUnreleasedChanges = changelogWithReleases.replace(
+    it('should throw if there are uncategorized changes in an older release', async () => {
+      const changelogWithUncategorizedChanges = changelogWithReleases.replace(
         '## [0.0.2] - 2020-01-01',
         '## [0.0.2] - 2020-01-01\n### Uncategorized\n- More changes\n',
       );
       await expect(
         validateChangelog({
-          changelogContent: changelogWithUnreleasedChanges,
+          changelogContent: changelogWithUncategorizedChanges,
           currentVersion: '1.0.0',
           repoUrl:
             'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
           isReleaseCandidate: false,
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toThrow('Uncategorized changes present in the changelog');
     });
   });
 
@@ -685,20 +685,20 @@ describe('validateChangelog', () => {
       ).rejects.toThrow('Uncategorized changes present in the changelog');
     });
 
-    it('should not throw if there are uncategorized changes in an older release', async () => {
-      const changelogWithUnreleasedChanges = changelogWithReleases.replace(
+    it('should throw if there are uncategorized changes in an older release', async () => {
+      const changelogWithUncategorizedChanges = changelogWithReleases.replace(
         '## [0.0.2] - 2020-01-01',
         '## [0.0.2] - 2020-01-01\n### Uncategorized\n- More changes\n',
       );
       await expect(
         validateChangelog({
-          changelogContent: changelogWithUnreleasedChanges,
+          changelogContent: changelogWithUncategorizedChanges,
           currentVersion: '1.0.0',
           repoUrl:
             'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
           isReleaseCandidate: true,
         }),
-      ).resolves.not.toThrow();
+      ).rejects.toThrow('Uncategorized changes present in the changelog');
     });
   });
 

--- a/src/validate-changelog.ts
+++ b/src/validate-changelog.ts
@@ -170,10 +170,6 @@ export async function validateChangelog({
   });
   const hasUnreleasedChanges =
     Object.keys(changelog.getUnreleasedChanges()).length !== 0;
-  const releaseChanges = currentVersion
-    ? changelog.getReleaseChanges(currentVersion)
-    : undefined;
-
   if (isReleaseCandidate) {
     if (!currentVersion) {
       throw new Error(
@@ -187,9 +183,16 @@ export async function validateChangelog({
       throw new MissingCurrentVersionError(currentVersion);
     } else if (hasUnreleasedChanges) {
       throw new UnreleasedChangesError();
-    } else if (
-      releaseChanges?.[ChangeCategory.Uncategorized]?.length &&
-      releaseChanges?.[ChangeCategory.Uncategorized]?.length !== 0
+    }
+  }
+
+  for (const release of changelog.getReleases()) {
+    const releaseChangesForVersion = changelog.getReleaseChanges(
+      release.version,
+    );
+    if (
+      releaseChangesForVersion[ChangeCategory.Uncategorized]?.length &&
+      releaseChangesForVersion[ChangeCategory.Uncategorized]?.length !== 0
     ) {
       throw new UncategorizedChangesError();
     }


### PR DESCRIPTION
## Explanation

Validation previously only rejected `Uncategorized` change categories for the current release when `isReleaseCandidate` was set to `true`. This meant `Uncategorized` entries could remain undetected in older releases or when running validation outside of release candidate mode.

This change moves the Uncategorized check out of the `isReleaseCandidate` block and applies it to all releases unconditionally, so any changelog containing an `### Uncategorized` heading will fail validation.

## References

Fixes #207

## Changelog

### Changed
- Validation now rejects `Uncategorized` headings in any release, regardless of `isReleaseCandidate` setting

## Checklist

- [x] Tests updated to reflect the new behavior
- [x] Lint passes
- [x] Type check passes
- [x] All 141 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation rules and may cause previously-valid changelogs/pipelines to fail, but change is small and localized to changelog validation.
> 
> **Overview**
> **Changelog validation is now stricter.** `validateChangelog` now scans *all* releases and throws `UncategorizedChangesError` if any release contains `ChangeCategory.Uncategorized`, regardless of the `isReleaseCandidate` flag.
> 
> **Tests were updated** to reflect the new behavior, changing prior expectations that uncategorized entries could be allowed in non-RC mode or older releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f25e8e35c4ac42c2ee729799d3a783b55065ceb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->