### PR TITLE
fix: add changelog entries in chronological order

### DIFF
--- a/src/update-changelog.test.ts
+++ b/src/update-changelog.test.ts
@@ -100,6 +100,46 @@ describe('updateChangelog', () => {
   });
 });
 
+describe('updateChangelog entry order', () => {
+  it('should add entries in chronological order (earliest first)', async () => {
+    // getNewChangeEntries returns commits in reverse chronological order
+    // (newest first) because git rev-list outputs newest commits first.
+    const newestFirstEntries = [
+      {
+        description: 'Third commit (#103)',
+        subject: 'Third commit (#103)',
+      },
+      {
+        description: 'Second commit (#102)',
+        subject: 'Second commit (#102)',
+      },
+      {
+        description: 'First commit (#101)',
+        subject: 'First commit (#101)',
+      },
+    ];
+    jest
+      .spyOn(ChangeLogUtils, 'getNewChangeEntries')
+      .mockResolvedValue(newestFirstEntries);
+
+    const result = await ChangeLogManager.updateChangelog({
+      ...changelogData,
+      autoCategorize: false,
+    });
+
+    // In the changelog, entries should appear in forward chronological
+    // order (earliest first), matching natural reading order.
+    expect(result).toBeDefined();
+    const changelog = result as string;
+    const firstIndex = changelog.indexOf('First commit (#101)');
+    const secondIndex = changelog.indexOf('Second commit (#102)');
+    const thirdIndex = changelog.indexOf('Third commit (#103)');
+
+    expect(firstIndex).toBeLessThan(secondIndex);
+    expect(secondIndex).toBeLessThan(thirdIndex);
+  });
+});
+
 describe('getCategory', () => {
   it('categorizes feat: prefix as Added', () => {
     const description = 'feat: add new feature';

--- a/src/update-changelog.ts
+++ b/src/update-changelog.ts
@@ -213,7 +213,7 @@ export async function updateChangelog({
     requirePrNumbers,
   });
 
-  for (const entry of newChangeEntries.reverse()) {
+  for (const entry of newChangeEntries) {
     const category = autoCategorize
       ? getCategory(entry.subject)
       : ChangeCategory.Uncategorized;


### PR DESCRIPTION
## Explanation

`git rev-list` returns commits newest-first. The loop in `updateChangelog`
called `.reverse()` before iterating, but `addChange` uses `unshift`
(prepend) internally. The combination of reverse + unshift produced entries
in reverse chronological order (newest first).

Removing `.reverse()` lets `unshift` naturally reverse the newest-first
input into the correct oldest-first (forward chronological) order in the
changelog.

## References

Fixes #210

## Changelog

### Fixed
- Changelog entries now appear in forward chronological order (earliest to latest)

## Checklist

- [x] Tests added to verify chronological ordering
- [x] All 142 tests pass
- [x] Lint and type check pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to changelog generation order plus a focused test; low blast radius limited to release note formatting.
> 
> **Overview**
> Ensures newly discovered commits are written to the changelog in forward chronological order (earliest first) by removing the extra `.reverse()` before adding entries.
> 
> Adds a regression test that mocks newest-first commit input and asserts the rendered changelog lists entries in the expected oldest-to-newest order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e55fb04ef50119d684acfa2292a30d0e9876d76d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->