### PR TITLE
Revert "6.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [6.0.0]
-
 ### Added
 
 - Add `--checkDeps` flag to `validate` command for dependency bump changelog validation ([#267](https://github.com/MetaMask/auto-changelog/pull/267))
@@ -17,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Additional CLI options: `--fromRef`, `--toRef`, `--remote`, `--baseBranch`
 - Add `dependencyBump` support to `Changelog` class with `addChange()` and new `updateChange()` method ([#267](https://github.com/MetaMask/auto-changelog/pull/267))
 - Detect `Bump`, `Update`, and `Upgrade` forms of dependency bump entries when parsing changelogs ([#267](https://github.com/MetaMask/auto-changelog/pull/267))
-- Export `getDependencyChanges`, `BaseRefNotFoundError`, `DependencyBump`, `DependencyCheckResult`, and `MissingDependencyEntriesError` from package entry point ([#267](https://github.com/MetaMask/auto-changelog/pull/267))
+- Export `getDependencyChanges`, `BaseRefNotFoundError`, `DependencyBump`, and `MissingDependencyEntriesError` from package entry point ([#267](https://github.com/MetaMask/auto-changelog/pull/267))
 
 ### Changed
 
@@ -300,8 +298,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Monorepo support ([#41](https://github.com/MetaMask/auto-changelog/pull/41))
   - Configurable repository URL, version, and changelog file path ([#33](https://github.com/MetaMask/auto-changelog/pull/33), [#31](https://github.com/MetaMask/auto-changelog/pull/31), [#30](https://github.com/MetaMask/auto-changelog/pull/30))
 
-[Unreleased]: https://github.com/MetaMask/auto-changelog/compare/v6.0.0...HEAD
-[6.0.0]: https://github.com/MetaMask/auto-changelog/compare/v5.3.2...v6.0.0
+[Unreleased]: https://github.com/MetaMask/auto-changelog/compare/v5.3.2...HEAD
 [5.3.2]: https://github.com/MetaMask/auto-changelog/compare/v5.3.1...v5.3.2
 [5.3.1]: https://github.com/MetaMask/auto-changelog/compare/v5.3.0...v5.3.1
 [5.3.0]: https://github.com/MetaMask/auto-changelog/compare/v5.2.0...v5.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/auto-changelog",
-  "version": "6.0.0",
+  "version": "5.3.2",
   "description": "Utilities for validating and updating \"Keep a Changelog\" formatted changelogs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts MetaMask/auto-changelog#280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reverts release metadata only (package version and changelog link/section adjustments) with no functional code changes.
> 
> **Overview**
> This PR **reverts the attempted `6.0.0` release metadata**, resetting `package.json` back to version `5.3.2`.
> 
> It also updates `CHANGELOG.md` to remove the `6.0.0` section/link references and restores the `[Unreleased]` compare link to start from `v5.3.2`, along with a small correction to the listed exported symbols in the unreleased notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4915760b3774991c9aa13b630690dd0ab1a9b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->