### PR TITLE
feat: Add option to use Oxfmt for formatting changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
     "outdent": "^0.8.0",
+    "oxfmt": "^0.45.0",
     "prettier": "^3.3.3",
     "prettier-plugin-packagejson": "^2.5.2",
     "rimraf": "^3.0.2",
@@ -78,7 +79,16 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
+    "oxfmt": "^0.45.0",
     "prettier": ">=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "oxfmt": {
+      "optional": true
+    },
+    "prettier": {
+      "optional": true
+    }
   },
   "packageManager": "yarn@3.2.4",
   "engines": {

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,5 +1,3 @@
-import * as markdown from 'prettier/plugins/markdown';
-import { format as formatWithPrettier } from 'prettier/standalone';
 import semver from 'semver';
 
 import {
@@ -8,19 +6,27 @@ import {
   unreleased,
   Version,
 } from './constants';
+import * as formatters from './formatters';
 import { PackageRename } from './shared-types';
+
+/**
+ * The name of the formatter to use when formatting the changelog string.
+ */
+export type FormatterName = keyof typeof formatters;
 
 /**
  * Format a Markdown changelog string.
  *
  * @param changelog - The changelog string to format.
+ * @param formatter - The name of the formatter to use.
  * @returns The formatted changelog string.
  */
-export async function format(changelog: string): Promise<string> {
-  return formatWithPrettier(changelog, {
-    parser: 'markdown',
-    plugins: [markdown],
-  });
+export async function format(
+  changelog: string,
+  formatter: FormatterName,
+): Promise<string> {
+  // eslint-disable-next-line import/namespace
+  return await formatters[formatter](changelog);
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import type { Argv } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 
-import { format, Formatter } from './changelog';
+import { format, Formatter, FormatterName } from './changelog';
 import { unreleased, Version } from './constants';
 import { readFile, writeFile } from './fs';
 import { createEmptyChangelog } from './init';
@@ -237,6 +237,12 @@ async function main() {
             description: `Expect the changelog to be formatted with Prettier.`,
             type: 'boolean',
           })
+          .option('formatter', {
+            description: 'The formatter to use for formatting the changelog.',
+            choices: ['prettier', 'oxfmt'],
+            type: 'string',
+            conflicts: ['prettier'],
+          })
           .option('useChangelogEntry', {
             default: false,
             description:
@@ -279,7 +285,14 @@ async function main() {
           .option('prettier', {
             default: false,
             description: `Expect the changelog to be formatted with Prettier.`,
+            deprecated: 'Use "--formatter prettier" instead.',
             type: 'boolean',
+          })
+          .option('formatter', {
+            description: 'The formatter to use for formatting the changelog.',
+            choices: ['prettier', 'oxfmt'],
+            type: 'string',
+            conflicts: ['prettier'],
           })
           .option('prLinks', {
             default: false,
@@ -342,6 +355,7 @@ async function main() {
     tagPrefix,
     fix,
     prettier: usePrettier,
+    formatter: formatterOption,
     versionBeforePackageRename,
     tagPrefixBeforePackageRename,
     autoCategorize,
@@ -387,8 +401,12 @@ async function main() {
   }
   const command = argv._[0];
 
+  const formatterTool = usePrettier
+    ? 'prettier'
+    : (formatterOption as FormatterName);
+
   const formatter = async (changelog: string) => {
-    return usePrettier ? await format(changelog) : changelog;
+    return await format(changelog, formatterTool);
   };
 
   const manifestPath = projectRootDirectory

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -233,15 +233,15 @@ async function main() {
               'Automatically categorize commits based on their messages.',
           })
           .option('prettier', {
-            default: true,
             description: `Expect the changelog to be formatted with Prettier.`,
+            deprecated: 'Use "--formatter prettier" instead.',
             type: 'boolean',
           })
           .option('formatter', {
             description: 'The formatter to use for formatting the changelog.',
             choices: ['prettier', 'oxfmt'],
+            default: 'prettier',
             type: 'string',
-            conflicts: ['prettier'],
           })
           .option('useChangelogEntry', {
             default: false,
@@ -283,16 +283,15 @@ async function main() {
             type: 'boolean',
           })
           .option('prettier', {
-            default: false,
             description: `Expect the changelog to be formatted with Prettier.`,
             deprecated: 'Use "--formatter prettier" instead.',
             type: 'boolean',
           })
           .option('formatter', {
             description: 'The formatter to use for formatting the changelog.',
-            choices: ['prettier', 'oxfmt'],
+            choices: ['prettier', 'oxfmt', 'none'],
+            default: 'none',
             type: 'string',
-            conflicts: ['prettier'],
           })
           .option('prLinks', {
             default: false,
@@ -401,12 +400,23 @@ async function main() {
   }
   const command = argv._[0];
 
-  const formatterTool = usePrettier
-    ? 'prettier'
-    : (formatterOption as FormatterName);
-
   const formatter = async (changelog: string) => {
-    return await format(changelog, formatterTool);
+    // If the deprecated `--prettier` flag is used, it takes precedence over the
+    // `--formatter` option. Otherwise, use the specified formatter, unless it's
+    // "none".
+    if (typeof usePrettier === 'boolean') {
+      if (usePrettier) {
+        return await format(changelog, 'prettier');
+      }
+
+      return changelog;
+    }
+
+    if (formatterOption && formatterOption !== 'none') {
+      return await format(changelog, formatterOption as FormatterName);
+    }
+
+    return changelog;
   };
 
   const manifestPath = projectRootDirectory

--- a/src/formatters.test.ts
+++ b/src/formatters.test.ts
@@ -1,0 +1,23 @@
+import { prettier } from './formatters';
+
+describe('oxfmt', () => {
+  // Oxfmt is ESM-only, and Jest doesn't work well with ESM. We'll want to
+  // switch to Vitest eventually anyway, so for now we'll just skip this test.
+  it.todo('formats changelog with Oxfmt when installed');
+
+  // Not easy to test with Jest, since Oxfmt is dynamically imported.
+  it.todo('throws an error with a clear message when Oxfmt is not installed');
+});
+
+describe('prettier', () => {
+  it('formats changelog with Prettier when installed', async () => {
+    const input = '# Changelog\n\n- Initial release';
+
+    expect(await prettier(input)).toBe('# Changelog\n\n- Initial release\n');
+  });
+
+  // Not easy to test with Jest, since Prettier is dynamically imported.
+  it.todo(
+    'throws an error with a clear message when Prettier is not installed',
+  );
+});

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -1,0 +1,48 @@
+/**
+ * Safely format a changelog with Prettier. If Prettier is not installed, it
+ * will throw an error with a clear message. This allows us to use Prettier for
+ * formatting when available, without making it a hard dependency of the
+ * project.
+ *
+ * @param changelog - The changelog string to format.
+ * @returns The formatted changelog string.
+ */
+export async function prettier(changelog: string): Promise<string> {
+  try {
+    const { format } = await import('prettier/standalone');
+    const markdown = await import('prettier/plugins/markdown');
+
+    return await format(changelog, {
+      parser: 'markdown',
+      plugins: [markdown],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to format changelog with Prettier. Is Prettier installed?\n\n${message}`,
+    );
+  }
+}
+
+/**
+ * Safely format a changelog with Oxfmt. If Oxfmt is not installed, it will
+ * throw an error with a clear message. This allows us to use Oxfmt for
+ * formatting when available, without making it a hard dependency of the
+ * project.
+ *
+ * @param changelog - The changelog string to format.
+ * @returns The formatted changelog string.
+ */
+export async function oxfmt(changelog: string): Promise<string> {
+  try {
+    const { format } = await import('oxfmt');
+    const result = await format('CHANGELOG.md', changelog);
+
+    return result.code;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to format changelog with Oxfmt. Is Oxfmt installed?\n\n${message}`,
+    );
+  }
+}

--- a/src/validate-changelog.test.ts
+++ b/src/validate-changelog.test.ts
@@ -711,7 +711,7 @@ describe('validateChangelog', () => {
           repoUrl:
             'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
           isReleaseCandidate: false,
-          formatter: format,
+          formatter: async (value) => await format(value, 'prettier'),
         }),
       ).resolves.not.toThrow();
     });
@@ -930,7 +930,7 @@ describe('validateChangelog', () => {
           repoUrl:
             'https://github.com/ExampleUsernameOrOrganization/ExampleRepository',
           isReleaseCandidate: false,
-          formatter: async (value: string) => await format(value),
+          formatter: async (value) => await format(value, 'prettier'),
         }),
       ).resolves.not.toThrow();
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,8 +872,13 @@ __metadata:
     typescript: ~4.8.4
     yargs: ^17.0.1
   peerDependencies:
-    oxfmt: "*"
+    oxfmt: ^0.45.0
     prettier: ">=3.0.0"
+  peerDependenciesMeta:
+    oxfmt:
+      optional: true
+    prettier:
+      optional: true
   bin:
     auto-changelog: dist/cli.mjs
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,7 @@ __metadata:
     execa: ^5.1.1
     jest: ^29.7.0
     outdent: ^0.8.0
+    oxfmt: ^0.45.0
     prettier: ^3.3.3
     prettier-plugin-packagejson: ^2.5.2
     rimraf: ^3.0.2
@@ -871,6 +872,7 @@ __metadata:
     typescript: ~4.8.4
     yargs: ^17.0.1
   peerDependencies:
+    oxfmt: "*"
     prettier: ">=3.0.0"
   bin:
     auto-changelog: dist/cli.mjs
@@ -1124,6 +1126,139 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": ^24.2.0
   checksum: fca3764548d5872535b9025c3b5fe6373fe588b287cb5b5259364796c1931bbe5e9ab8a86a5274ce43bb2b3e43b730067c3b86b6b1ade12a98cd59b2e8b3610d
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-android-arm-eabi@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-android-arm-eabi@npm:0.45.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-android-arm64@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-android-arm64@npm:0.45.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-darwin-arm64@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-darwin-arm64@npm:0.45.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-darwin-x64@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-darwin-x64@npm:0.45.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-freebsd-x64@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-freebsd-x64@npm:0.45.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm-gnueabihf@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-arm-gnueabihf@npm:0.45.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm-musleabihf@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-arm-musleabihf@npm:0.45.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm64-gnu@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-arm64-gnu@npm:0.45.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-arm64-musl@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-arm64-musl@npm:0.45.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-ppc64-gnu@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-ppc64-gnu@npm:0.45.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-riscv64-gnu@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-riscv64-gnu@npm:0.45.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-riscv64-musl@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-riscv64-musl@npm:0.45.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-s390x-gnu@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-s390x-gnu@npm:0.45.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-x64-gnu@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-x64-gnu@npm:0.45.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-linux-x64-musl@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-linux-x64-musl@npm:0.45.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-openharmony-arm64@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-openharmony-arm64@npm:0.45.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-arm64-msvc@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-win32-arm64-msvc@npm:0.45.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-ia32-msvc@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-win32-ia32-msvc@npm:0.45.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@oxfmt/binding-win32-x64-msvc@npm:0.45.0":
+  version: 0.45.0
+  resolution: "@oxfmt/binding-win32-x64-msvc@npm:0.45.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -5086,6 +5221,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oxfmt@npm:^0.45.0":
+  version: 0.45.0
+  resolution: "oxfmt@npm:0.45.0"
+  dependencies:
+    "@oxfmt/binding-android-arm-eabi": 0.45.0
+    "@oxfmt/binding-android-arm64": 0.45.0
+    "@oxfmt/binding-darwin-arm64": 0.45.0
+    "@oxfmt/binding-darwin-x64": 0.45.0
+    "@oxfmt/binding-freebsd-x64": 0.45.0
+    "@oxfmt/binding-linux-arm-gnueabihf": 0.45.0
+    "@oxfmt/binding-linux-arm-musleabihf": 0.45.0
+    "@oxfmt/binding-linux-arm64-gnu": 0.45.0
+    "@oxfmt/binding-linux-arm64-musl": 0.45.0
+    "@oxfmt/binding-linux-ppc64-gnu": 0.45.0
+    "@oxfmt/binding-linux-riscv64-gnu": 0.45.0
+    "@oxfmt/binding-linux-riscv64-musl": 0.45.0
+    "@oxfmt/binding-linux-s390x-gnu": 0.45.0
+    "@oxfmt/binding-linux-x64-gnu": 0.45.0
+    "@oxfmt/binding-linux-x64-musl": 0.45.0
+    "@oxfmt/binding-openharmony-arm64": 0.45.0
+    "@oxfmt/binding-win32-arm64-msvc": 0.45.0
+    "@oxfmt/binding-win32-ia32-msvc": 0.45.0
+    "@oxfmt/binding-win32-x64-msvc": 0.45.0
+    tinypool: 2.1.0
+  dependenciesMeta:
+    "@oxfmt/binding-android-arm-eabi":
+      optional: true
+    "@oxfmt/binding-android-arm64":
+      optional: true
+    "@oxfmt/binding-darwin-arm64":
+      optional: true
+    "@oxfmt/binding-darwin-x64":
+      optional: true
+    "@oxfmt/binding-freebsd-x64":
+      optional: true
+    "@oxfmt/binding-linux-arm-gnueabihf":
+      optional: true
+    "@oxfmt/binding-linux-arm-musleabihf":
+      optional: true
+    "@oxfmt/binding-linux-arm64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-arm64-musl":
+      optional: true
+    "@oxfmt/binding-linux-ppc64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-riscv64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-riscv64-musl":
+      optional: true
+    "@oxfmt/binding-linux-s390x-gnu":
+      optional: true
+    "@oxfmt/binding-linux-x64-gnu":
+      optional: true
+    "@oxfmt/binding-linux-x64-musl":
+      optional: true
+    "@oxfmt/binding-openharmony-arm64":
+      optional: true
+    "@oxfmt/binding-win32-arm64-msvc":
+      optional: true
+    "@oxfmt/binding-win32-ia32-msvc":
+      optional: true
+    "@oxfmt/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    oxfmt: bin/oxfmt
+  checksum: 4033d56419780c9507ab4c72ad4cac47eedcd310d4a288bcf24326302226da2fd12441292fca3b16ffabb6c9cc8d209af803505a3824d4f4c19cc1ba7456ae4a
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -6059,6 +6263,13 @@ __metadata:
   dependencies:
     any-promise: ^1.0.0
   checksum: 84e1b804bfec49f3531215f17b4a6e50fd4397b5f7c1bccc427b9c656e1ecfb13ea79d899930184f78bc2f57285c54d9a50a590c8868f4f0cef5c1d9f898b05e
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:2.1.0":
+  version: 2.1.0
+  resolution: "tinypool@npm:2.1.0"
+  checksum: f45eafaecb602509301716e70344d6532f20d29a38c2bd163de849fc0bfa3536090fcb7fc92b42b62698e586680cf45813f8b98c3995b63e2c9deb844da87ef4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds a new `--formatter` option, which can be set to either "prettier" or "oxfmt", and deprecates the `--prettier` option. I've also refactored the logic to load Prettier dynamically, so both Oxfmt and Prettier are now _optional_ peer dependencies.

Tested in `MetaMask/core`:
- https://github.com/MetaMask/core/pull/8442

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes CLI flags and formatting behavior via dynamic imports, which could affect consumers relying on the deprecated `--prettier` flag or missing optional peer deps at runtime.
> 
> **Overview**
> Adds a new `--formatter` CLI option to choose changelog formatting (`prettier` or `oxfmt`, with `none` for `validate`) and deprecates the legacy `--prettier` flag (which still takes precedence when provided).
> 
> Refactors changelog formatting to route through new `src/formatters.ts` helpers that dynamically import Prettier/Oxfmt and throw clearer errors when the chosen formatter isn’t installed, and updates tests and package metadata to treat `prettier`/`oxfmt` as *optional* peer dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0fc35a1fc33d44408ecc8373220d09f2ec67b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->