### PR TITLE
chore: Export Oxfmt and Prettier formatters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   type DependencyBump,
   type ReleaseChanges,
 } from './changelog';
+export { oxfmt, prettier } from './formatters';
 export {
   BaseRefNotFoundError,
   getDependencyChanges,


### PR DESCRIPTION
We currently redefine a formatting function in other projects using `auto-changelog` (such as `create-release-branch` and `action-create-release-pr`). Instead, we can just export the functions for those other projects to import.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: exposes existing `oxfmt`/`prettier` helpers via the package entrypoint with no behavior changes, but it slightly expands the public API surface.
> 
> **Overview**
> **Exports the existing changelog formatting helpers** (`oxfmt` and `prettier`) from `src/index.ts`, making them available to consumers via the package’s top-level API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6076d80ed66ba7d18dfbe32e4c565085d7cb7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->