### PR TITLE
fix: stop leaving stray commas when parsing legacy multi-group PR links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Consume comma separators between adjacent legacy long-form PR link groups (e.g. `([#A](url)), ([#B](url))`) when parsing change entries so they are not left behind in the description after PR-link extraction.
+- Consume comma separators between adjacent legacy long-form PR link groups (e.g. `([#A](url)), ([#B](url))`) when parsing change entries so they are not left behind in the description after PR-link extraction. ([#286](https://github.com/MetaMask/auto-changelog/pull/286))
 
 ## [6.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Consume comma separators between adjacent legacy long-form PR link groups (e.g. `([#A](url)), ([#B](url))`) when parsing change entries so they are not left behind in the description after PR-link extraction.
+
 ## [6.1.0]
 
 ### Added

--- a/src/parse-changelog.test.ts
+++ b/src/parse-changelog.test.ts
@@ -994,6 +994,87 @@ describe('parseChangelog', () => {
       });
     });
 
+    it('should parse changelog with two adjacent parenthesized PR link groups (legacy form)', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](${repoUrl}/pull/100)), ([#200](${repoUrl}/pull/200))
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100', '200'],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog with three adjacent parenthesized PR link groups (legacy form)', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](${repoUrl}/pull/100)), ([#200](${repoUrl}/pull/200)), ([#300](${repoUrl}/pull/300))
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100', '200', '300'],
+          },
+        ],
+      });
+    });
+
+    it('should parse changelog mixing canonical and legacy PR link group forms', () => {
+      const changelogContent = createChangelog(
+        COMMON_HEADER,
+        outdent`
+          ## [1.0.0]
+          ### Changed
+          - Change something ([#100](${repoUrl}/pull/100), [#200](${repoUrl}/pull/200)), ([#300](${repoUrl}/pull/300))
+        `,
+        COMMON_REFERENCE_LINKS_1,
+      );
+
+      const changelog = parseChangelog({
+        changelogContent,
+        repoUrl,
+        shouldExtractPrLinks: true,
+      });
+
+      expect(changelog.getReleaseChanges('1.0.0')).toStrictEqual({
+        Changed: [
+          {
+            description: 'Change something',
+            prNumbers: ['100', '200', '300'],
+          },
+        ],
+      });
+    });
+
     it('should parse changelog with pull request links at end of first line of change description with sub-bullets', () => {
       const changelogContent = createChangelog(
         COMMON_HEADER,

--- a/src/parse-changelog.ts
+++ b/src/parse-changelog.ts
@@ -295,10 +295,18 @@ function extractPrLinks(
   // changelog entries include links to PRs from other repos like packages that were bumped.
   // We don't want to accidentally extract those.
 
+  // A single parenthesized group of one or more comma-separated long PR
+  // links, e.g. `([#123](...))` or `([#123](...), [#456](...))`.
+  const longLinkGroup = `\\(\\s*(?:\\[#\\d+\\]\\([^)]*${repoName}[^)]*\\)\\s*,?\\s*)+\\)`;
+
   // eslint-disable-next-line prefer-regex-literals
   const longGroupMatchPattern = new RegExp(
-    // Example of long match group: " ([#123](...), [#456](...))"
-    `\\s+\\(\\s*(\\[#\\d+\\]\\([^)]*${repoName}[^)]*\\)\\s*,?\\s*)+\\)`,
+    // Match the canonical form `(... , ...)` and the legacy form where
+    // multiple parenthesized groups are written next to each other separated
+    // by commas: `([#123](...)), ([#456](...))`. In the legacy form the
+    // inter-group `, ` must be consumed so it isn't left behind in the
+    // description after replacement.
+    `\\s+${longLinkGroup}(?:\\s*,\\s*${longLinkGroup})*`,
     'gu',
   );
 


### PR DESCRIPTION
## Summary

`extractPrLinks` leaves stray commas in change descriptions when parsing the legacy form `([#A](url)), ([#B](url))`. The mangled output surfaces whenever `auto-changelog` re-stringifies a changelog that contains historical entries in that form. The release tool (`@metamask/create-release-branch`) hits this on every release run because `updateChangelog` calls `parseChangelog({ shouldExtractPrLinks: true })`.

## Repro

Older changelog entry:

```
- Add new dependency `@metamask/keyring-sdk@1.2.0` ([#478](.../pull/478)), ([#482](.../pull/482)), ([#496](.../pull/496))
```

After parse + re-stringify:

```
- Add new dependency `@metamask/keyring-sdk@1.2.0`,,, ([#478](.../pull/478), [#482](.../pull/482), [#496](.../pull/496))
```

One stray comma per inter-group separator. PR references are still extracted correctly. Only the description text is polluted.

## Root cause

`src/parse-changelog.ts` matches long PR-link groups with this regex:

```ts
\s+\(\s*(\[#\d+\]\([^)]*${repoName}[^)]*\)\s*,?\s*)+\)
```

The pattern matches a single parenthesized group. When the input is `([#A]), ([#B]), ([#C])`, each `([#X])` is matched as its own group. The `, ` separators sit between matches, outside the pattern, so `String.replace(pattern, '')` leaves them in place and they end up tacked onto the description.

## Fix

Extend the pattern so one match consumes the full sequence of adjacent groups, including the comma separators between them:

```ts
const longLinkGroup = `\\(\\s*(?:\\[#\\d+\\]\\([^)]*${repoName}[^)]*\\)\\s*,?\\s*)+\\)`;
new RegExp(`\\s+${longLinkGroup}(?:\\s*,\\s*${longLinkGroup})*`, 'gu');
```

Three shapes are now handled correctly:

1. Canonical, one group with comma-separated refs: `([#A](url), [#B](url))`
2. Legacy, adjacent single-ref groups: `([#A](url)), ([#B](url))`
3. Mixed: `([#A](url), [#B](url)), ([#C](url))`

`longMatchPattern` (PR-number extraction) is unchanged. It finds individual `[#X](url)` parts regardless of grouping.

## Use cases this fixes

Any caller of `parseChangelog` / `updateChangelog` whose input contains historical entries in the legacy multi-group form. Concretely:

- `@metamask/create-release-branch` running on monorepos. It calls `updateChangelog` per changed package, so any package with legacy-form entries in older release sections gets mangled on its next release.
- Direct callers that pass `shouldExtractPrLinks: true` to `parseChangelog`.

PR numbers are still extracted correctly, so no data is lost. The damage is to the description text, which has to be cleaned up by hand before merging the release PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the core regex used to strip long-form PR links from changelog entries, which could affect parsing edge cases; added tests cover the new legacy and mixed formats.
> 
> **Overview**
> Fixes `extractPrLinks` long-form PR link stripping to treat multiple adjacent parenthesized link groups separated by commas as a single match, preventing leftover comma characters in the resulting change description.
> 
> Adds regression tests for legacy `([#A](url)), ([#B](url))` and mixed canonical/legacy groupings, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71bee804305b29db78ae965948392924dbbc5eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->