### PR TITLE
fix: pin fflate to 0.8.2 to work around attw tarball-read crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "test": "jest && attw --pack",
     "test:watch": "jest --watch"
   },
+  "resolutions": {
+    "fflate": "0.8.2"
+  },
   "dependencies": {
     "@octokit/rest": "^20.0.0",
     "diff": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,7 +3166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.8.2":
+"fflate@npm:0.8.2":
   version: 0.8.2
   resolution: "fflate@npm:0.8.2"
   checksum: 29470337b85d3831826758e78f370e15cda3169c5cd4477c9b5eea2402261a74b2975bae816afabe1c15d21d98591e0d30a574f7103aa117bff60756fa3035d4


### PR DESCRIPTION
Pins fflate because 0.8.3 changed Gunzip's streaming callback to emit trailing empty chunks at end-of-stream. @arethetypeswrong/core (via @andrewbranch/untar.js) captures only the last chunk, so it gets an empty buffer, returns [] from untar, and crashes with "Cannot read properties of undefined (reading 'filename')" in the [Compatibility test job](https://github.com/MetaMask/auto-changelog/actions/runs/26110268413/job/76786731126) of https://github.com/MetaMask/auto-changelog/pull/287

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency resolution-only change that pins `fflate` to a known-good version to stabilize the test/tooling pipeline.
> 
> **Overview**
> Pins transitive dependency `fflate` to `0.8.2` using Yarn `resolutions` to avoid a regression that breaks `attw --pack`.
> 
> Updates `yarn.lock` to reflect the forced `fflate@0.8.2` resolution (removing the `^0.8.2` range entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c5e6fe0b8e1ef91ae1137041dd39ab880c6dae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->