### PR TITLE
ci: Add missing top-level `permissions` to publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,10 @@ on:
         required: false
       SLACK_WEBHOOK_URL:
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to the publish-release workflow, following the principle of least privilege.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission tightening with no application or release logic changes; job overrides preserve existing publish behavior.
> 
> **Overview**
> Adds **workflow-level** `permissions: contents: read` to `publish-release.yml` so the reusable workflow defaults to least privilege instead of relying on the repository default token scope.
> 
> Job-level overrides are unchanged: `publish-release` still requests `contents: write`, and `publish-npm` still sets `contents: read` plus `id-token: write` for OIDC publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1743f0975fc13c099510b911ac29971834aeaa8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->