### PR TITLE
fix: add missing shebang to CLI entrypoint

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { promises as fs, constants as fsConstants } from 'fs';
 import path from 'path';
 import semver from 'semver';


### PR DESCRIPTION
The CLI entrypoint `src/cli.ts` was missing a `#!/usr/bin/env node` shebang line, which is required for the compiled output to be executable directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 99d1420ff33f6ba19b51909351c336f5af0bc3f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->